### PR TITLE
feat: fit the mobile layout to a single screen

### DIFF
--- a/src/app/(public)/play/Play.tsx
+++ b/src/app/(public)/play/Play.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import ActionButtons from "@/components/gto/ActionButtons";
+import ActionLine from "@/components/gto/ActionLine";
 import GtoTable from "@/components/gto/GtoTable";
 import PnlChart from "@/components/play/PnlChart";
 import {
@@ -174,7 +176,7 @@ export default function Play() {
 
   if (modelStatus === "loading") {
     return (
-      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+      <div className="flex min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] items-center justify-center">
         <div className="text-slate-500">Loading GTO strategy model...</div>
       </div>
     );
@@ -182,7 +184,7 @@ export default function Play() {
 
   if (modelStatus === "unavailable") {
     return (
-      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4">
+      <div className="flex min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] items-center justify-center px-4">
         <div className="max-w-lg text-center space-y-3">
           <h1 className="text-xl font-bold text-slate-900 dark:text-white">
             Strategy model not available
@@ -211,9 +213,9 @@ export default function Play() {
       : null;
 
   const sessionPanel = (
-    <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4 sm:p-6 shadow-sm">
-      <div className="flex items-baseline justify-between mb-4">
-        <h2 className="text-sm font-medium text-slate-400 uppercase tracking-wider">
+    <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-3 sm:p-6 shadow-sm">
+      <div className="flex items-baseline justify-between mb-2 sm:mb-4">
+        <h2 className="text-xs sm:text-sm font-medium text-slate-400 uppercase tracking-wider">
           Session PnL
         </h2>
         <button
@@ -224,10 +226,10 @@ export default function Play() {
           Reset
         </button>
       </div>
-      <div className="grid grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-3 gap-2 mb-2 sm:mb-4">
         <div>
           <div
-            className={`text-2xl font-bold tabular-nums ${
+            className={`text-xl sm:text-2xl font-bold tabular-nums ${
               session.handsPlayed === 0
                 ? "text-slate-900 dark:text-white"
                 : pnlPositive
@@ -242,7 +244,7 @@ export default function Play() {
           </div>
         </div>
         <div>
-          <div className="text-2xl font-bold tabular-nums text-slate-900 dark:text-white">
+          <div className="text-xl sm:text-2xl font-bold tabular-nums text-slate-900 dark:text-white">
             {session.handsPlayed}
           </div>
           <div className="text-[10px] text-slate-400 uppercase tracking-wider">
@@ -250,7 +252,7 @@ export default function Play() {
           </div>
         </div>
         <div>
-          <div className="text-2xl font-bold tabular-nums text-slate-900 dark:text-white">
+          <div className="text-xl sm:text-2xl font-bold tabular-nums text-slate-900 dark:text-white">
             {session.handsPlayed === 0
               ? "—"
               : Math.round(winRateBb100(session))}
@@ -265,80 +267,77 @@ export default function Play() {
   );
 
   return (
-    <div className="min-h-screen bg-white dark:bg-[#0a0a0a]">
-      <main className="container mx-auto px-4 sm:px-6 py-4 sm:py-8 max-w-[1400px]">
-        <div className="mb-4 sm:mb-8 text-center lg:text-left">
-          <h1 className="text-xl sm:text-2xl font-bold text-slate-900 dark:text-white">
+    <div className="min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] bg-white dark:bg-[#0a0a0a]">
+      <main className="container mx-auto px-3 sm:px-6 py-3 sm:py-8 max-w-[1400px]">
+        {/* On a phone the header nav already marks the page, so the title
+            block collapses to nothing and gives its ~70px to the table. */}
+        <div className="sm:mb-8 text-center lg:text-left">
+          <h1 className="sr-only sm:not-sr-only text-xl sm:text-2xl font-bold text-slate-900 dark:text-white">
             Heads-Up vs. the Bot
           </h1>
-          <p className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
+          <p className="hidden sm:block text-xs sm:text-sm text-slate-500 dark:text-slate-400">
             Full hands against the Deep CFR–solved strategy. Both reload to 100
             BB each hand (the depth it was solved for); your PnL accumulates
             locally.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-8">
-          <div className="lg:col-span-8 flex flex-col gap-4">
-            {spot ? (
-              <GtoTable
-                spot={spot}
-                villainCards={
-                  phase === "showdown" ? (outcome?.villainCards ?? null) : null
-                }
-                heroRank={
-                  phase === "showdown" ? (outcome?.heroRank ?? null) : null
-                }
-                villainRank={
-                  phase === "showdown" ? (outcome?.villainRank ?? null) : null
-                }
-                villainThinking={phase === "dealing"}
-                result={result}
-              />
-            ) : (
-              <div className="flex min-h-[400px] sm:min-h-[560px] items-center justify-center rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/50">
-                <div className="text-slate-500">Dealing...</div>
-              </div>
-            )}
-            {spot && spot.lineDescription.length > 0 && (
-              <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4 text-xs sm:text-sm text-slate-600 dark:text-slate-400 space-y-1">
-                <div className="text-xs font-medium text-slate-400 uppercase tracking-wider">
-                  Action so far
+        {/* `contents` dissolves the two columns on a phone so their four
+            panels become direct grid items and `order-*` can interleave them
+            as table -> decision -> recap -> session, putting the buttons in
+            reach without scrolling past the recap. From `lg` the wrappers
+            become blocks again and the original 8/4 columns are restored. */}
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 lg:gap-8 items-start">
+          <div className="contents lg:block lg:col-span-8 lg:space-y-4">
+            <div className="order-1">
+              {spot ? (
+                <GtoTable
+                  spot={spot}
+                  villainCards={
+                    phase === "showdown"
+                      ? (outcome?.villainCards ?? null)
+                      : null
+                  }
+                  heroRank={
+                    phase === "showdown" ? (outcome?.heroRank ?? null) : null
+                  }
+                  villainRank={
+                    phase === "showdown" ? (outcome?.villainRank ?? null) : null
+                  }
+                  villainThinking={phase === "dealing"}
+                  result={result}
+                />
+              ) : (
+                <div className="flex min-h-[280px] sm:min-h-[560px] items-center justify-center rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/50">
+                  <div className="text-slate-500">Dealing...</div>
                 </div>
-                {spot.lineDescription.map((line) => (
-                  <div key={line}>{line}</div>
-                ))}
-              </div>
+              )}
+            </div>
+            {spot && (
+              <ActionLine lines={spot.lineDescription} className="order-3" />
             )}
           </div>
 
-          <div className="lg:col-span-4 flex flex-col gap-4">
-            <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-6 shadow-sm">
+          <div className="contents lg:block lg:col-span-4 lg:space-y-4">
+            <div className="order-2 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4 sm:p-6 shadow-sm">
               {phase === "hero" && spot ? (
                 <>
-                  <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+                  <h2 className="text-base sm:text-lg font-semibold text-slate-900 dark:text-white mb-3 sm:mb-4">
                     Your decision ({spot.streetName})
                   </h2>
-                  <div className="space-y-2">
-                    {legalActions(history).map((action) => (
-                      <button
-                        key={action}
-                        type="button"
-                        onClick={() => onHeroAction(action)}
-                        className="w-full py-2.5 sm:py-3 px-4 bg-slate-100 hover:bg-blue-600 hover:text-white dark:bg-slate-800 dark:hover:bg-blue-600 text-slate-900 dark:text-white text-sm sm:text-base font-medium rounded-lg transition-all active:scale-[0.98]"
-                      >
-                        {spot.actionLabels[action] ?? action}
-                      </button>
-                    ))}
-                  </div>
+                  <ActionButtons
+                    actions={legalActions(history)}
+                    labels={spot.actionLabels}
+                    onAction={onHeroAction}
+                  />
                 </>
               ) : phase === "showdown" && outcome ? (
                 <>
-                  <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-1">
+                  <h2 className="text-base sm:text-lg font-semibold text-slate-900 dark:text-white mb-1">
                     {outcome.headline}
                   </h2>
                   <div
-                    className={`text-3xl font-bold tabular-nums mb-4 ${
+                    className={`text-2xl sm:text-3xl font-bold tabular-nums mb-3 sm:mb-4 ${
                       outcome.delta > 0
                         ? "text-emerald-600 dark:text-emerald-400"
                         : outcome.delta < 0
@@ -357,7 +356,7 @@ export default function Play() {
                   </button>
                 </>
               ) : (
-                <div className="flex min-h-[120px] items-center justify-center text-sm text-slate-500">
+                <div className="flex min-h-[64px] sm:min-h-[120px] items-center justify-center text-sm text-slate-500">
                   <span>Villain is acting</span>
                   <span className="thinking-dots ml-0.5 inline-flex">
                     <span>.</span>
@@ -368,7 +367,7 @@ export default function Play() {
               )}
             </div>
 
-            {sessionPanel}
+            <div className="order-4">{sessionPanel}</div>
           </div>
         </div>
       </main>

--- a/src/app/(public)/ranges/RangeExplorer.tsx
+++ b/src/app/(public)/ranges/RangeExplorer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import ActionButtons from "@/components/gto/ActionButtons";
 import BoardSelector from "@/components/gto/BoardSelector";
 import RangeGrid from "@/components/gto/RangeGrid";
 import {
@@ -131,7 +132,7 @@ export default function RangeExplorer() {
 
   if (modelStatus === "loading") {
     return (
-      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+      <div className="flex min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] items-center justify-center">
         <div className="text-slate-500">Loading GTO strategy model...</div>
       </div>
     );
@@ -139,7 +140,7 @@ export default function RangeExplorer() {
 
   if (modelStatus === "unavailable") {
     return (
-      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4">
+      <div className="flex min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] items-center justify-center px-4">
         <div className="max-w-lg text-center space-y-3">
           <h1 className="text-xl font-bold text-slate-900 dark:text-white">
             Strategy model not available
@@ -155,14 +156,16 @@ export default function RangeExplorer() {
   }
 
   return (
-    <div className="min-h-screen bg-white dark:bg-[#0a0a0a]">
-      <main className="container mx-auto px-4 sm:px-6 py-4 sm:py-8 max-w-[1500px]">
-        <div className="mb-4 sm:mb-6 flex flex-wrap items-end justify-between gap-2">
+    <div className="min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] bg-white dark:bg-[#0a0a0a]">
+      <main className="container mx-auto px-3 sm:px-6 py-3 sm:py-8 max-w-[1500px]">
+        {/* On a phone the header nav already marks the page, so the title
+            block collapses to nothing and gives its space to the grid. */}
+        <div className="sm:mb-6 flex flex-wrap items-end justify-between gap-2">
           <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-slate-900 dark:text-white">
+            <h1 className="sr-only sm:not-sr-only text-xl sm:text-2xl font-bold text-slate-900 dark:text-white">
               GTO Ranges
             </h1>
-            <p className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
+            <p className="hidden sm:block text-xs sm:text-sm text-slate-500 dark:text-slate-400">
               Walk the action tree; the grid shows the solved strategy for every
               starting hand of the player to act.
             </p>
@@ -170,7 +173,7 @@ export default function RangeExplorer() {
         </div>
 
         {/* Node header: street, pot, board, line breadcrumb */}
-        <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4 mb-4 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+        <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-3 py-2 sm:p-4 mb-3 sm:mb-4 flex flex-wrap items-center gap-x-3 sm:gap-x-6 gap-y-1 sm:gap-y-2 text-xs sm:text-sm">
           <span className="font-semibold text-slate-900 dark:text-white">
             {STREET_NAMES[summary.street]}
           </span>
@@ -209,7 +212,7 @@ export default function RangeExplorer() {
               )}
             </span>
           )}
-          <span className="ml-auto flex gap-2">
+          <span className="ml-auto flex gap-1.5 sm:gap-2">
             <button
               type="button"
               onClick={undo}
@@ -229,8 +232,9 @@ export default function RangeExplorer() {
           </span>
         </div>
 
-        {/* Decision buttons / chance / terminal */}
-        <div className="mb-4 flex flex-wrap gap-2">
+        {/* Decision buttons / chance / terminal. The shared ActionButtons grid
+            keeps six sizings to three rows on a phone instead of six. */}
+        <div className="mb-3 sm:mb-4">
           {atTerminal ? (
             <span className="text-sm text-slate-500 dark:text-slate-400 py-2">
               Hand over — use Undo to step back.
@@ -239,26 +243,24 @@ export default function RangeExplorer() {
             <button
               type="button"
               onClick={() => setSelectingBoard(true)}
-              className="py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+              className="w-full sm:w-auto py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
             >
               Select {STREET_NAMES[summary.street]}…
             </button>
           ) : (
-            legalActions(nav).map((a, i) => (
-              <button
-                key={a}
-                type="button"
-                onClick={() => takeAction(a)}
-                className="py-2 px-4 bg-slate-100 hover:bg-blue-600 hover:text-white dark:bg-slate-800 dark:hover:bg-blue-600 text-slate-900 dark:text-white text-sm font-medium rounded-lg transition-colors"
-              >
-                {labels[a] ?? a}
-                {grid && (
-                  <span className="ml-2 font-mono text-xs opacity-70">
+            <ActionButtons
+              actions={legalActions(nav)}
+              labels={labels}
+              onAction={takeAction}
+              layout="inline"
+              suffix={(_a, i) =>
+                grid && (
+                  <span className="font-mono text-[10px] sm:text-xs opacity-70">
                     {(grid.aggregate[i] * 100).toFixed(0)}%
                   </span>
-                )}
-              </button>
-            ))
+                )
+              }
+            />
           )}
         </div>
 

--- a/src/app/(public)/trainer/Trainer.tsx
+++ b/src/app/(public)/trainer/Trainer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import ActionButtons from "@/components/gto/ActionButtons";
+import ActionLine from "@/components/gto/ActionLine";
 import GtoFeedback from "@/components/gto/GtoFeedback";
 import GtoTable from "@/components/gto/GtoTable";
 import {
@@ -97,12 +99,15 @@ export default function Trainer() {
     }
   }, [modelStatus, nextSpot]);
 
+  // The label sits beside the chips on a phone and above them from `sm` up
+  // (`sm:w-full` forces its own line), so the whole control is one row on mobile.
   const streetPanel = (
-    <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4">
-      <div className="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
-        Practice streets
-      </div>
-      <div className="flex flex-wrap gap-2">
+    <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-3 py-2.5 sm:p-4">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        <div className="text-[10px] sm:text-xs font-medium text-slate-400 uppercase tracking-wider sm:w-full sm:mb-2">
+          <span className="sm:hidden">Streets</span>
+          <span className="hidden sm:inline">Practice streets</span>
+        </div>
         {STREET_OPTIONS.map((name, s) => {
           const active = streets.has(s);
           return (
@@ -111,7 +116,7 @@ export default function Trainer() {
               type="button"
               aria-pressed={active}
               onClick={() => toggleStreet(s)}
-              className={`px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors ${
+              className={`px-2.5 sm:px-3 py-1 sm:py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors ${
                 active
                   ? "bg-blue-600 text-white"
                   : "bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
@@ -122,7 +127,7 @@ export default function Trainer() {
           );
         })}
       </div>
-      <p className="text-[11px] text-slate-400 dark:text-slate-500 mt-2">
+      <p className="hidden sm:block text-[11px] text-slate-400 dark:text-slate-500 mt-2">
         Spots are dealt only on the selected streets — changing the selection
         deals a new spot. At least one stays on.
       </p>
@@ -131,7 +136,7 @@ export default function Trainer() {
 
   if (modelStatus === "loading") {
     return (
-      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+      <div className="flex min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] items-center justify-center">
         <div className="text-slate-500">Loading GTO strategy model...</div>
       </div>
     );
@@ -139,7 +144,7 @@ export default function Trainer() {
 
   if (modelStatus === "unavailable") {
     return (
-      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4">
+      <div className="flex min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] items-center justify-center px-4">
         <div className="max-w-lg text-center space-y-3">
           <h1 className="text-xl font-bold text-slate-900 dark:text-white">
             Strategy model not available
@@ -158,13 +163,15 @@ export default function Trainer() {
   }
 
   return (
-    <div className="min-h-screen bg-white dark:bg-[#0a0a0a]">
-      <main className="container mx-auto px-4 sm:px-6 py-4 sm:py-8 max-w-[1400px]">
-        <div className="mb-4 sm:mb-8 text-center lg:text-left">
-          <h1 className="text-xl sm:text-2xl font-bold text-slate-900 dark:text-white">
+    <div className="min-h-[calc(100dvh-3rem)] sm:min-h-[calc(100vh-4rem)] bg-white dark:bg-[#0a0a0a]">
+      <main className="container mx-auto px-3 sm:px-6 py-3 sm:py-8 max-w-[1400px]">
+        {/* On a phone the header nav already marks the page, so the title
+            block collapses to nothing and gives its ~70px to the table. */}
+        <div className="sm:mb-8 text-center lg:text-left">
+          <h1 className="sr-only sm:not-sr-only text-xl sm:text-2xl font-bold text-slate-900 dark:text-white">
             GTO Trainer
           </h1>
-          <p className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
+          <p className="hidden sm:block text-xs sm:text-sm text-slate-500 dark:text-slate-400">
             Play spots against a Deep CFR–solved strategy (100 BB, discretized
             bet sizes).
           </p>
@@ -191,42 +198,33 @@ export default function Trainer() {
             <div className="text-slate-500">Dealing next spot...</div>
           </div>
         ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-8">
-            <div className="lg:col-span-8 flex flex-col gap-4">
-              <GtoTable spot={spot} />
-              {spot.lineDescription.length > 0 && (
-                <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4 text-xs sm:text-sm text-slate-600 dark:text-slate-400 space-y-1">
-                  <div className="text-xs font-medium text-slate-400 uppercase tracking-wider">
-                    Action so far
-                  </div>
-                  {spot.lineDescription.map((line) => (
-                    <div key={line}>{line}</div>
-                  ))}
-                </div>
-              )}
+          // `contents` dissolves the two columns on a phone so their four
+          // panels become direct grid items and `order-*` can interleave them
+          // as table -> decision -> recap -> streets, putting the buttons in
+          // reach without scrolling past the recap. From `lg` the wrappers
+          // become blocks again and the original 8/4 columns are restored.
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 lg:gap-8 items-start">
+            <div className="contents lg:block lg:col-span-8 lg:space-y-4">
+              <div className="order-1">
+                <GtoTable spot={spot} />
+              </div>
+              <ActionLine lines={spot.lineDescription} className="order-3" />
             </div>
 
-            <div className="lg:col-span-4">
-              <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-6 shadow-sm">
-                <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+            <div className="contents lg:block lg:col-span-4 lg:space-y-4">
+              <div className="order-2 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4 sm:p-6 shadow-sm">
+                <h2 className="text-base sm:text-lg font-semibold text-slate-900 dark:text-white mb-3 sm:mb-4">
                   {userAction === null
                     ? `Your decision (${spot.streetName})`
                     : "GTO"}
                 </h2>
 
                 {userAction === null ? (
-                  <div className="space-y-2">
-                    {strategy.map(({ action }) => (
-                      <button
-                        key={action}
-                        type="button"
-                        onClick={() => setUserAction(action)}
-                        className="w-full py-2.5 sm:py-3 px-4 bg-slate-100 hover:bg-blue-600 hover:text-white dark:bg-slate-800 dark:hover:bg-blue-600 text-slate-900 dark:text-white text-sm sm:text-base font-medium rounded-lg transition-colors"
-                      >
-                        {spot.actionLabels[action] ?? action}
-                      </button>
-                    ))}
-                  </div>
+                  <ActionButtons
+                    actions={strategy.map((s) => s.action)}
+                    labels={spot.actionLabels}
+                    onAction={setUserAction}
+                  />
                 ) : (
                   <GtoFeedback
                     spot={spot}
@@ -239,7 +237,7 @@ export default function Trainer() {
                 )}
               </div>
 
-              <div className="mt-4">{streetPanel}</div>
+              <div className="order-4">{streetPanel}</div>
             </div>
           </div>
         )}

--- a/src/components/cards/CardDisplay.tsx
+++ b/src/components/cards/CardDisplay.tsx
@@ -6,13 +6,37 @@ interface CardDisplayProps {
   card: Card | null;
   onClick?: () => void;
   isSelectable?: boolean;
+  /**
+   * Shrink the card on small screens so a full seat row (or a five-card
+   * board) fits one phone line. Desktop sizing is unchanged either way.
+   */
+  compact?: boolean;
 }
+
+/** [box, rank text, suit glyph, inner gap] per size, mobile -> sm. */
+const SIZES = {
+  default: [
+    "w-14 h-20 sm:w-20 sm:h-28",
+    "text-[10px] sm:text-sm",
+    "text-2xl sm:text-4xl",
+    "gap-1",
+  ],
+  compact: [
+    "w-11 h-16 sm:w-20 sm:h-28",
+    "text-[9px] sm:text-sm",
+    "text-xl sm:text-4xl",
+    "gap-0.5 sm:gap-1",
+  ],
+} as const;
 
 export default function CardDisplay({
   card,
   onClick,
   isSelectable = false,
+  compact = false,
 }: CardDisplayProps) {
+  const [box, rankText, suitText, gap] = SIZES[compact ? "compact" : "default"];
+
   const suitSymbols: Record<Suit, string> = {
     hearts: "♥",
     diamonds: "♦",
@@ -34,7 +58,7 @@ export default function CardDisplay({
         onClick={onClick}
         disabled={!isSelectable}
         className={`
-          w-14 h-20 sm:w-20 sm:h-28 bg-white dark:bg-slate-900 border-2 border-dashed border-slate-300 dark:border-slate-700
+          ${box} bg-white dark:bg-slate-900 border-2 border-dashed border-slate-300 dark:border-slate-700
           rounded-md flex items-center justify-center
           ${isSelectable ? "hover:border-slate-400 dark:hover:border-slate-600 cursor-pointer" : "cursor-default"}
           transition-colors
@@ -52,16 +76,18 @@ export default function CardDisplay({
       type="button"
       onClick={onClick}
       className={`
-        w-14 h-20 sm:w-20 sm:h-28 bg-white dark:bg-slate-900 border-2 border-slate-300 dark:border-slate-700
-        rounded-md flex flex-col items-center justify-center gap-1
+        ${box} bg-white dark:bg-slate-900 border-2 border-slate-300 dark:border-slate-700
+        rounded-md flex flex-col items-center justify-center ${gap}
         ${onClick ? "hover:border-red-500 dark:hover:border-red-500 cursor-pointer" : "cursor-default"}
         transition-colors
       `}
     >
-      <span className="text-[10px] sm:text-sm font-semibold text-slate-600 dark:text-slate-400">
+      <span
+        className={`${rankText} font-semibold text-slate-600 dark:text-slate-400`}
+      >
         {card.rank}
       </span>
-      <span className={`text-2xl sm:text-4xl ${suitColors[card.suit]}`}>
+      <span className={`${suitText} ${suitColors[card.suit]}`}>
         {suitSymbols[card.suit]}
       </span>
     </button>

--- a/src/components/gto/ActionButtons.tsx
+++ b/src/components/gto/ActionButtons.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Splits a spot label like `Raise to 12 BB (½ pot)` into the amount that
+ * matters ("Raise to 12 BB") and the sizing hint ("½ pot"), so the hint can
+ * ride on a second, quieter line. That keeps the button legible at half
+ * width, which is what lets the action list sit two-up on a phone instead
+ * of eating six full-width rows.
+ */
+export function splitActionLabel(label: string): {
+  main: string;
+  hint: string | null;
+} {
+  const m = /^(.*?)\s*\(([^)]*)\)$/.exec(label);
+  return m ? { main: m[1], hint: m[2] } : { main: label, hint: null };
+}
+
+interface ActionButtonsProps {
+  actions: string[];
+  labels: Record<string, string>;
+  onAction: (action: string) => void;
+  /**
+   * `stack` fills a narrow side panel (one per row from `sm` up); `inline`
+   * wraps them in a single row, for a full-width toolbar. Both are a
+   * two-column grid on a phone.
+   */
+  layout?: "stack" | "inline";
+  /** Extra per-action annotation, e.g. the solved frequency on /ranges. */
+  suffix?: (action: string, index: number) => React.ReactNode;
+}
+
+export default function ActionButtons({
+  actions,
+  labels,
+  onAction,
+  layout = "stack",
+  suffix,
+}: ActionButtonsProps) {
+  // With an odd count the passive action (fold/check, always first) takes the
+  // full row so the aggressive sizes stay paired and no cell is left empty.
+  const oddFirst = actions.length % 2 === 1;
+
+  return (
+    <div
+      className={`grid grid-cols-2 gap-2 ${
+        layout === "stack" ? "sm:grid-cols-1" : "sm:flex sm:flex-wrap"
+      }`}
+    >
+      {actions.map((action, i) => {
+        const { main, hint } = splitActionLabel(labels[action] ?? action);
+        const extra = suffix?.(action, i);
+        return (
+          <button
+            key={action}
+            type="button"
+            onClick={() => onAction(action)}
+            className={`flex flex-col sm:flex-row items-center justify-center gap-x-1.5 leading-tight
+              py-2 px-2 sm:px-4 rounded-lg transition-all active:scale-[0.98]
+              ${layout === "stack" ? "sm:py-3" : ""}
+              bg-slate-100 hover:bg-blue-600 hover:text-white
+              dark:bg-slate-800 dark:hover:bg-blue-600 text-slate-900 dark:text-white
+              ${oddFirst && i === 0 ? "col-span-2 sm:col-span-1" : ""}`}
+          >
+            <span
+              className={`font-medium ${
+                layout === "stack"
+                  ? "text-[13px] sm:text-base"
+                  : "text-[13px] sm:text-sm"
+              }`}
+            >
+              {main}
+            </span>
+            {(hint || extra) && (
+              <span className="flex items-center gap-1.5 text-[10px] sm:text-xs">
+                {hint && <span className="opacity-60">{hint}</span>}
+                {extra}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/gto/ActionLine.tsx
+++ b/src/components/gto/ActionLine.tsx
@@ -1,0 +1,31 @@
+import type { SpotInfo } from "@/lib/gto/strategy";
+
+/**
+ * The hand's action so far, one line per street. On a phone the section
+ * label is dropped — each line already opens with its street name — and the
+ * type tightens, so the recap costs a couple of lines rather than a block.
+ */
+export default function ActionLine({
+  lines,
+  className = "",
+}: {
+  lines: SpotInfo["lineDescription"];
+  /** Placement classes — the component is its own grid cell, so an empty
+      line list leaves no gap behind. */
+  className?: string;
+}) {
+  if (lines.length === 0) return null;
+
+  return (
+    <div
+      className={`${className} bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-3 py-2 sm:p-4 text-[11px] sm:text-sm text-slate-600 dark:text-slate-400 space-y-0.5 sm:space-y-1`}
+    >
+      <div className="hidden sm:block text-xs font-medium text-slate-400 uppercase tracking-wider">
+        Action so far
+      </div>
+      {lines.map((line) => (
+        <div key={line}>{line}</div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/gto/GtoFeedback.tsx
+++ b/src/components/gto/GtoFeedback.tsx
@@ -66,20 +66,22 @@ export default function GtoFeedback({
     spot.toCallBB > 0 ? breakEvenEquity(spot.potBB, spot.toCallBB) : null;
 
   return (
-    <div className="space-y-4">
-      <div className={`p-3 rounded-lg border ${v.className}`}>
+    <div className="space-y-3 sm:space-y-4">
+      <div className={`px-3 py-2 sm:p-3 rounded-lg border ${v.className}`}>
         <div className="font-semibold text-sm sm:text-base">{v.label}</div>
-        <div className="text-xs sm:text-sm mt-0.5">{v.detail}</div>
+        <div className="text-[11px] sm:text-sm mt-0.5 leading-snug">
+          {v.detail}
+        </div>
       </div>
 
       <div>
-        <h3 className="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+        <h3 className="text-[10px] sm:text-xs font-medium text-slate-400 uppercase tracking-wider mb-1.5 sm:mb-2">
           GTO frequencies at this spot
         </h3>
-        <div className="space-y-2">
+        <div className="space-y-1.5 sm:space-y-2">
           {sorted.map(({ action, probability }) => (
             <div key={action}>
-              <div className="flex justify-between text-xs sm:text-sm mb-0.5">
+              <div className="flex justify-between gap-2 text-[11px] sm:text-sm mb-0.5">
                 <span
                   className={
                     action === userAction
@@ -90,11 +92,11 @@ export default function GtoFeedback({
                   {spot.actionLabels[action] ?? action}
                   {action === userAction && " ← you"}
                 </span>
-                <span className="font-mono text-slate-900 dark:text-white">
+                <span className="font-mono tabular-nums text-slate-900 dark:text-white">
                   {(probability * 100).toFixed(1)}%
                 </span>
               </div>
-              <div className="h-2 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden">
+              <div className="h-1.5 sm:h-2 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden">
                 <div
                   className={`h-full rounded-full ${
                     action === userAction
@@ -109,34 +111,42 @@ export default function GtoFeedback({
         </div>
       </div>
 
+      {/* Two stats side by side rather than two sentences: the comparison is
+          the point, and it costs one line instead of three. */}
       {requiredEquity !== null && (
-        <div className="p-3 bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-100 dark:border-slate-800 text-xs sm:text-sm text-slate-600 dark:text-slate-400 space-y-1">
+        <div className="grid grid-cols-2 gap-2 px-3 py-2 bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-100 dark:border-slate-800">
           <div>
-            Pot odds is{" "}
-            <span className="font-mono">
-              {(requiredEquity * 100).toFixed(1)}%
-            </span>
-            .
-          </div>
-          {equityPending ? (
-            <div className="text-slate-400 dark:text-slate-500">
-              Estimating your calling equity…
+            <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wider">
+              Pot odds
             </div>
-          ) : equity !== null ? (
-            <div>
-              Calling equity is{" "}
-              <span
-                className={`font-mono font-semibold ${
+            <div className="font-mono tabular-nums text-sm sm:text-base text-slate-900 dark:text-white">
+              {(requiredEquity * 100).toFixed(1)}%
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wider">
+              Your equity
+            </div>
+            {equityPending ? (
+              <div className="text-xs text-slate-400 dark:text-slate-500 py-0.5">
+                Estimating…
+              </div>
+            ) : equity !== null ? (
+              <div
+                className={`font-mono tabular-nums font-semibold text-sm sm:text-base ${
                   equity >= requiredEquity
                     ? "text-green-600 dark:text-green-400"
                     : "text-red-600 dark:text-red-400"
                 }`}
               >
                 {(equity * 100).toFixed(1)}%
-              </span>
-              .
-            </div>
-          ) : null}
+              </div>
+            ) : (
+              <div className="font-mono text-sm sm:text-base text-slate-400">
+                —
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/components/gto/GtoTable.tsx
+++ b/src/components/gto/GtoTable.tsx
@@ -36,8 +36,8 @@ function PositionBadge({ seat }: { seat: number }) {
 
 function HiddenCard() {
   return (
-    <div className="w-14 h-20 sm:w-20 sm:h-28 bg-white dark:bg-slate-800 rounded-md border-2 border-slate-200 dark:border-slate-700 flex items-center justify-center shadow-sm">
-      <div className="w-10 h-16 sm:w-16 sm:h-24 bg-slate-100 dark:bg-slate-700/50 rounded-sm" />
+    <div className="w-11 h-16 sm:w-20 sm:h-28 bg-white dark:bg-slate-800 rounded-md border-2 border-slate-200 dark:border-slate-700 flex items-center justify-center shadow-sm">
+      <div className="w-8 h-12 sm:w-16 sm:h-24 bg-slate-100 dark:bg-slate-700/50 rounded-sm" />
     </div>
   );
 }
@@ -52,6 +52,80 @@ function ringFor(
   return "";
 }
 
+/**
+ * Seat name, stack and (at showdown) made-hand category. Sits beside the
+ * cards on a phone and under them from `sm` up, so each seat costs one
+ * line instead of three on a small screen.
+ */
+function SeatMeta({
+  name,
+  stackBB,
+  seat,
+  rank,
+  emphasis,
+}: {
+  name: string;
+  stackBB: number;
+  seat: number;
+  rank: string | null;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-start sm:items-center gap-0.5 sm:gap-3">
+      <div className="flex items-center gap-1.5 sm:gap-2">
+        <span
+          className={`text-xs sm:text-sm font-medium ${
+            emphasis
+              ? "text-slate-900 dark:text-white"
+              : "text-slate-600 dark:text-slate-400"
+          }`}
+        >
+          {name} · {stackBB} BB
+          <span className="hidden sm:inline"> behind</span>
+        </span>
+        <PositionBadge seat={seat} />
+      </div>
+      {rank && (
+        <span className="text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          {rank}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** One pot figure. Inline label on a phone, stacked from `sm` up. */
+function PotStat({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline gap-1.5 sm:flex-col sm:items-center sm:gap-0">
+      <span
+        className={`text-[10px] sm:text-xs font-medium uppercase tracking-wider sm:mb-1 ${
+          accent ? "text-red-500" : "text-slate-400"
+        }`}
+      >
+        {label}
+      </span>
+      <span
+        className={`text-lg sm:text-2xl font-bold ${
+          accent
+            ? "text-red-600 dark:text-red-400"
+            : "text-slate-900 dark:text-white"
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
 export default function GtoTable({
   spot,
   villainCards = null,
@@ -61,12 +135,12 @@ export default function GtoTable({
   result = null,
 }: GtoTableProps) {
   return (
-    <div className="bg-slate-50 dark:bg-slate-900/50 rounded-xl border border-slate-200 dark:border-slate-800 p-4 sm:p-8 min-h-[400px] sm:min-h-[560px] flex flex-col justify-between gap-4 sm:gap-8 relative overflow-hidden">
+    <div className="bg-slate-50 dark:bg-slate-900/50 rounded-xl border border-slate-200 dark:border-slate-800 p-3 sm:p-8 sm:min-h-[560px] flex flex-col justify-between gap-3 sm:gap-8 relative overflow-hidden">
       <div className="absolute inset-0 pointer-events-none opacity-[0.03] dark:opacity-[0.05] bg-[radial-gradient(circle_at_center,var(--tw-gradient-stops))] from-slate-900 via-transparent to-transparent" />
       {/* Ambient felt glow — slow, low-opacity blue breathing so the table isn't static. */}
       <div className="felt-drift absolute inset-0 pointer-events-none bg-[radial-gradient(55%_45%_at_50%_42%,rgba(37,99,235,0.10),transparent_70%)]" />
 
-      <div className="flex flex-col items-center gap-3 z-10 w-full">
+      <div className="flex items-center justify-center gap-3 sm:flex-col sm:gap-3 z-10 w-full">
         <div
           className={`card-perspective flex gap-1 sm:gap-3 rounded-xl p-1 ${
             villainCards
@@ -83,7 +157,7 @@ export default function GtoTable({
                 className="animate-flip"
                 style={{ animationDelay: `${i * 0.1}s` }}
               >
-                <CardDisplay card={card} />
+                <CardDisplay card={card} compact />
               </div>
             ))
           ) : (
@@ -97,32 +171,27 @@ export default function GtoTable({
             </>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs sm:text-sm font-medium text-slate-600 dark:text-slate-400">
-            Villain · {spot.villainStackBB} BB behind
-          </span>
-          <PositionBadge seat={1 - spot.heroSeat} />
-        </div>
-        {villainRank && (
-          <span className="text-[11px] sm:text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            {villainRank}
-          </span>
-        )}
+        <SeatMeta
+          name="Villain"
+          stackBB={spot.villainStackBB}
+          seat={1 - spot.heroSeat}
+          rank={villainRank}
+        />
       </div>
 
-      <div className="flex flex-col items-center gap-6 z-10 w-full">
+      <div className="flex flex-col items-center gap-2 sm:gap-6 z-10 w-full">
         {/* Fixed-height board slot — reserves room for the flop cards so the
             table doesn't jump vertically between preflop and postflop. */}
-        <div className="flex min-h-[6.5rem] sm:min-h-[9.5rem] items-center justify-center">
+        <div className="flex min-h-[4.75rem] sm:min-h-[9.5rem] items-center justify-center max-w-full">
           {spot.board.length > 0 ? (
-            <div className="flex gap-2 sm:gap-3 p-2 sm:p-4 bg-white/50 dark:bg-slate-800/50 rounded-2xl border border-slate-100 dark:border-slate-700/50 backdrop-blur-sm max-w-full overflow-x-auto">
+            <div className="flex gap-1 sm:gap-3 p-1.5 sm:p-4 bg-white/50 dark:bg-slate-800/50 rounded-xl sm:rounded-2xl border border-slate-100 dark:border-slate-700/50 backdrop-blur-sm max-w-full overflow-x-auto">
               {spot.board.map((card, i) => (
                 <div
                   key={`${card.rank}-${card.suit}-${i}`}
                   className="animate-deal"
                   style={{ animationDelay: `${Math.min(i, 2) * 0.07}s` }}
                 >
-                  <CardDisplay card={card} />
+                  <CardDisplay card={card} compact />
                 </div>
               ))}
             </div>
@@ -133,54 +202,37 @@ export default function GtoTable({
           )}
         </div>
 
-        <div className="flex items-center gap-4 sm:gap-8">
-          <div className="flex flex-col items-center">
-            <span className="text-[10px] sm:text-xs font-medium text-slate-400 uppercase tracking-wider mb-1">
-              Pot
-            </span>
-            <span
-              key={spot.potBB}
-              className="animate-pot-pop text-xl sm:text-2xl font-bold text-slate-900 dark:text-white"
-            >
-              {spot.potBB} BB
-            </span>
-          </div>
+        <div className="flex items-center gap-3 sm:gap-8">
+          <span key={spot.potBB} className="animate-pot-pop">
+            <PotStat label="Pot" value={`${spot.potBB} BB`} />
+          </span>
           {spot.toCallBB > 0 && (
             <>
-              <div className="w-px h-6 sm:h-8 bg-slate-200 dark:bg-slate-700" />
-              <div className="flex flex-col items-center">
-                <span className="text-[10px] sm:text-xs font-medium text-red-500 uppercase tracking-wider mb-1">
-                  To Call
-                </span>
-                <span className="text-xl sm:text-2xl font-bold text-red-600 dark:text-red-400">
-                  {spot.toCallBB} BB
-                </span>
-              </div>
+              <div className="w-px h-5 sm:h-8 bg-slate-200 dark:bg-slate-700" />
+              <PotStat label="To Call" value={`${spot.toCallBB} BB`} accent />
             </>
           )}
         </div>
       </div>
 
-      <div className="flex flex-col items-center gap-3 z-10">
-        <div className={`flex gap-3 rounded-xl p-1 ${ringFor("hero", result)}`}>
+      <div className="flex items-center justify-center gap-3 sm:flex-col sm:gap-3 z-10 w-full">
+        <div
+          className={`flex gap-1 sm:gap-3 rounded-xl p-1 ${ringFor("hero", result)}`}
+        >
           <div className="animate-deal">
-            <CardDisplay card={spot.heroCards[0]} />
+            <CardDisplay card={spot.heroCards[0]} compact />
           </div>
           <div className="animate-deal" style={{ animationDelay: "0.06s" }}>
-            <CardDisplay card={spot.heroCards[1]} />
+            <CardDisplay card={spot.heroCards[1]} compact />
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-slate-900 dark:text-white">
-            Hero · {spot.heroStackBB} BB behind
-          </span>
-          <PositionBadge seat={spot.heroSeat} />
-        </div>
-        {heroRank && (
-          <span className="text-[11px] sm:text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            {heroRank}
-          </span>
-        )}
+        <SeatMeta
+          name="Hero"
+          stackBB={spot.heroStackBB}
+          seat={spot.heroSeat}
+          rank={heroRank}
+          emphasis
+        />
       </div>
     </div>
   );

--- a/src/components/gto/RangeGrid.tsx
+++ b/src/components/gto/RangeGrid.tsx
@@ -217,12 +217,14 @@ export default function RangeGrid({ grid }: RangeGridProps) {
           ))}
         </div>
 
-        {/* Legend — identity is never color-alone */}
-        <div className="flex flex-wrap gap-x-4 gap-y-1 mt-3">
+        {/* Legend — identity is never color-alone. Below `sm` the two
+            breakdown tables carry the same swatches, so only the one label
+            they lack needs repeating here. */}
+        <div className="flex flex-wrap gap-x-3 sm:gap-x-4 gap-y-1 mt-2 sm:mt-3">
           {grid.actions.map((a) => (
             <span
               key={a}
-              className="inline-flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400"
+              className="hidden sm:inline-flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400"
             >
               <span
                 className="w-3 h-3 rounded-[2px] inline-block"
@@ -231,7 +233,7 @@ export default function RangeGrid({ grid }: RangeGridProps) {
               {ACTION_NAMES[a]}
             </span>
           ))}
-          <span className="inline-flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400">
+          <span className="inline-flex items-center gap-1.5 text-[10px] sm:text-xs text-slate-600 dark:text-slate-400">
             <span
               className="w-3 h-3 rounded-[2px] inline-block"
               style={{ background: "var(--gto-blocked)" }}
@@ -241,57 +243,61 @@ export default function RangeGrid({ grid }: RangeGridProps) {
         </div>
       </div>
 
-      {/* Hover / tap detail panel — the tooltip layer plus table view */}
+      {/* Hover / tap detail panel — the tooltip layer plus table view.
+          Range total and the focused cell sit side by side on a phone; the
+          panel is a single narrow column from `lg` up. */}
       <div className="lg:w-56 shrink-0">
-        <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-100 dark:border-slate-800 p-3 sticky top-20">
-          <div className="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
-            Range total
+        <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-100 dark:border-slate-800 p-2.5 sm:p-3 sticky top-16 lg:top-20 grid grid-cols-2 lg:grid-cols-1 gap-x-4">
+          <div>
+            <div className="text-[10px] sm:text-xs font-medium text-slate-400 uppercase tracking-wider mb-1.5 sm:mb-2">
+              Range total
+            </div>
+            <div
+              className="h-2 sm:h-3 flex rounded-full overflow-hidden mb-1"
+              style={{ gap: "1px" }}
+            >
+              {grid.aggregate.map((p, i) =>
+                p > 0.001 ? (
+                  <div
+                    key={grid.actions[i]}
+                    style={{
+                      width: `${p * 100}%`,
+                      background: ACTION_COLORS[grid.actions[i]],
+                    }}
+                  />
+                ) : null,
+              )}
+            </div>
+            <table className="w-full text-[11px] sm:text-xs lg:mb-3">
+              <tbody>
+                {grid.actions.map((a, i) => (
+                  <tr key={a}>
+                    <td className="py-0.5 text-slate-600 dark:text-slate-400">
+                      <span
+                        className="w-2 h-2 rounded-[2px] inline-block mr-1.5"
+                        style={{ background: ACTION_COLORS[a] }}
+                      />
+                      {ACTION_NAMES[a]}
+                    </td>
+                    <td className="py-0.5 text-right font-mono tabular-nums text-slate-900 dark:text-white">
+                      {(grid.aggregate[i] * 100).toFixed(1)}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-          <div
-            className="h-3 flex rounded-full overflow-hidden mb-1"
-            style={{ gap: "1px" }}
-          >
-            {grid.aggregate.map((p, i) =>
-              p > 0.001 ? (
-                <div
-                  key={grid.actions[i]}
-                  style={{
-                    width: `${p * 100}%`,
-                    background: ACTION_COLORS[grid.actions[i]],
-                  }}
-                />
-              ) : null,
-            )}
-          </div>
-          <table className="w-full text-xs mb-3">
-            <tbody>
-              {grid.actions.map((a, i) => (
-                <tr key={a}>
-                  <td className="py-0.5 text-slate-600 dark:text-slate-400">
-                    <span
-                      className="w-2 h-2 rounded-[2px] inline-block mr-1.5"
-                      style={{ background: ACTION_COLORS[a] }}
-                    />
-                    {ACTION_NAMES[a]}
-                  </td>
-                  <td className="py-0.5 text-right font-mono text-slate-900 dark:text-white">
-                    {(grid.aggregate[i] * 100).toFixed(1)}%
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
 
           {detail && (
-            <>
-              <div className="text-xs font-medium text-slate-400 uppercase tracking-wider mb-1">
+            <div>
+              <div className="text-[10px] sm:text-xs font-medium text-slate-400 uppercase tracking-wider mb-1.5 sm:mb-1">
                 {detail.label}
                 <span className="ml-2 normal-case font-normal">
                   {detail.combos} combo{detail.combos === 1 ? "" : "s"}
                 </span>
               </div>
               {detail.probs ? (
-                <table className="w-full text-xs">
+                <table className="w-full text-[11px] sm:text-xs">
                   <tbody>
                     {grid.actions.map((a, i) => (
                       <tr key={a}>
@@ -302,7 +308,7 @@ export default function RangeGrid({ grid }: RangeGridProps) {
                           />
                           {ACTION_NAMES[a]}
                         </td>
-                        <td className="py-0.5 text-right font-mono text-slate-900 dark:text-white">
+                        <td className="py-0.5 text-right font-mono tabular-nums text-slate-900 dark:text-white">
                           {((detail.probs?.[i] ?? 0) * 100).toFixed(1)}%
                         </td>
                       </tr>
@@ -319,7 +325,7 @@ export default function RangeGrid({ grid }: RangeGridProps) {
                 combos={detail.comboList}
                 actions={grid.actions}
               />
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,10 +14,10 @@ export default function Header() {
 
   return (
     <header className="sticky top-0 z-50 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-[#0a0a0a]">
-      <div className="container mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
+      <div className="container mx-auto px-3 sm:px-6 h-12 sm:h-16 flex items-center justify-between">
         <div className="flex items-center gap-2 sm:gap-8">
           <Link href="/" className="flex items-center gap-2 group">
-            <span className="text-lg font-semibold text-slate-900 dark:text-white">
+            <span className="text-base sm:text-lg font-semibold text-slate-900 dark:text-white">
               GTO Lab
             </span>
           </Link>

--- a/src/components/play/PnlChart.tsx
+++ b/src/components/play/PnlChart.tsx
@@ -87,7 +87,7 @@ export default function PnlChart({ results, pnlBB }: PnlChartProps) {
 
   if (results.length === 0) {
     return (
-      <div className="flex h-[200px] items-center justify-center text-xs text-slate-400 dark:text-slate-500">
+      <div className="flex h-[110px] sm:h-[200px] items-center justify-center text-xs text-slate-400 dark:text-slate-500">
         Play a hand to start your PnL curve.
       </div>
     );
@@ -96,10 +96,10 @@ export default function PnlChart({ results, pnlBB }: PnlChartProps) {
   // Anchor the curve at the origin so the first hand's swing reads from zero.
   const data = [{ hand: 0, cumBB: 0, deltaBB: 0 }, ...results];
 
-  if (!mounted) return <div className="h-[200px]" />;
+  if (!mounted) return <div className="h-[110px] sm:h-[200px]" />;
 
   return (
-    <div className="h-[200px] w-full">
+    <div className="h-[110px] sm:h-[200px] w-full">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart
           data={data}


### PR DESCRIPTION
On a phone the panels stacked table -> action recap -> decision, so the buttons — the only thing you actually interact with — sat two scrolls down. Measured at 390x844, /trainer and /play now render in 845px of content against an 844px viewport (was 893), with no horizontal overflow on any page.

- reorder the stack to table -> decision -> recap -> secondary panel. The two columns become `contents` below `lg`, which dissolves them so their panels are direct grid items and `order-*` can interleave them; from `lg` up the wrappers are blocks again and the 8/4 columns render exactly as before.
- halve the table's vertical cost on mobile: seat rows go horizontal (cards beside the name, not above), pot labels sit inline, and cards shrink to 44x64 via a `compact` prop on CardDisplay. Desktop card sizing is untouched.
- new shared ActionButtons: two-up grid on mobile, so six bet sizings take three rows instead of six. Labels split on the trailing parenthetical ("Raise to 12 BB" + a dimmed "1/2 pot" hint) to stay legible at half width; with an odd count the passive action takes the full row so the sizings stay paired. /ranges uses layout="inline" to keep its desktop toolbar row.
- new shared ActionLine for the "action so far" recap, previously duplicated in Trainer and Play.
- page titles go sr-only on mobile (the header nav already marks the page), and the page wrappers subtract the header height so `min-h-screen` no longer forces a scroll of exactly the header's size.
- denser secondary panels: GtoFeedback's pot-odds prose becomes a two-stat row, RangeGrid puts its two breakdown tables side by side, and the PnL chart is shorter on mobile.

Desktop was diffed before/after at 1440x900 and is unchanged, except that button hints now read "All-in  20 BB" rather than "All-in (20 BB)".