### PR TITLE
feat: expose the solver to AI agents via MCP (stdio + remote HTTP)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Rate limiting for the hosted MCP endpoint (src/app/api/[transport]).
+# Optional — with these unset, rate limiting is disabled (fail-open) and every
+# request passes, which is what you want for local dev and self-hosting.
+#
+# Create an Upstash Redis database (https://upstash.com) and paste its REST
+# credentials here (and into the Vercel project's Environment Variables).
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gto-lab": {
+      "command": "pnpm",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,65 +12,14 @@ pnpm dev
 The app expects a trained strategy model at `public/models/holdem_strategy.onnx` (one is
 committed after training; see below to retrain).
 
-## Use it from an AI agent (MCP)
+## Use it from an AI assistant (MCP)
 
-The solver is exposed to AI agents over [MCP](https://modelcontextprotocol.io), so an
-agent can ask *"what's GTO here?"* and get answers straight from the strategy net.
-Two tools:
+The solver is exposed to AI assistants (Claude, Cursor, …) over
+[MCP](https://modelcontextprotocol.io), so an agent can ask *"what's GTO here?"* and
+get answers straight from the strategy net.
 
-- **`get_gto_strategy`** — the Nash action mix at a hero decision.
-- **`get_range_grid`** — the 13×13 starting-hand range for the player to act on a
-  public line.
-
-Both take either plain poker notation (`hero: "As Ks"`, `position: "SB"`, `board`, a
-readable `line`) or the engine's raw token form. Full tool reference: [`mcp/README.md`](mcp/README.md).
-
-### Remote (hosted) — Streamable HTTP
-
-The easiest path: connect straight to our hosted instance — no clone, no deploy.
-Point any Streamable-HTTP-capable client at **`https://gto-thingy.vercel.app/api/mcp`**:
-
-```json
-{
-  "mcpServers": {
-    "gto-lab": { "url": "https://gto-thingy.vercel.app/api/mcp" }
-  }
-}
-```
-
-For a stdio-only client, bridge with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
-
-```json
-{
-  "mcpServers": {
-    "gto-lab": { "command": "npx", "args": ["mcp-remote", "https://gto-thingy.vercel.app/api/mcp"] }
-  }
-}
-```
-
-The hosted instance is a shared, rate-limited best-effort service. For heavy or
-production use, deploy your own (`/api/mcp` on any Vercel deployment of this app) or
-run the local stdio server below.
-
-### Local — stdio
-
-Run the server straight from a clone (no deployment, native inference):
-
-```bash
-pnpm mcp          # speaks MCP over stdio
-```
-
-Register it with your agent. **Claude Code** users get it automatically from the
-checked-in [`.mcp.json`](.mcp.json); for **Claude Desktop** (`claude_desktop_config.json`)
-or any other client, add:
-
-```json
-{
-  "mcpServers": {
-    "gto-lab": { "command": "pnpm", "args": ["mcp"], "cwd": "/absolute/path/to/gto-lab" }
-  }
-}
-```
+- **End users** — step-by-step setup for every app is on the site: **[/agents](https://gto-thingy.vercel.app/agents)**. The easiest path is pointing a client at the hosted server, `https://gto-thingy.vercel.app/api/mcp`.
+- **Developers** — the tools, transports (stdio + remote HTTP), and self-hosting are documented in [`mcp/README.md`](mcp/README.md).
 
 ## The solver (`solver/`)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,66 @@ pnpm dev
 The app expects a trained strategy model at `public/models/holdem_strategy.onnx` (one is
 committed after training; see below to retrain).
 
+## Use it from an AI agent (MCP)
+
+The solver is exposed to AI agents over [MCP](https://modelcontextprotocol.io), so an
+agent can ask *"what's GTO here?"* and get answers straight from the strategy net.
+Two tools:
+
+- **`get_gto_strategy`** — the Nash action mix at a hero decision.
+- **`get_range_grid`** — the 13×13 starting-hand range for the player to act on a
+  public line.
+
+Both take either plain poker notation (`hero: "As Ks"`, `position: "SB"`, `board`, a
+readable `line`) or the engine's raw token form. Full tool reference: [`mcp/README.md`](mcp/README.md).
+
+### Remote (hosted) — Streamable HTTP
+
+The easiest path: connect straight to our hosted instance — no clone, no deploy.
+Point any Streamable-HTTP-capable client at **`https://gto-thingy.vercel.app/api/mcp`**:
+
+```json
+{
+  "mcpServers": {
+    "gto-lab": { "url": "https://gto-thingy.vercel.app/api/mcp" }
+  }
+}
+```
+
+For a stdio-only client, bridge with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
+
+```json
+{
+  "mcpServers": {
+    "gto-lab": { "command": "npx", "args": ["mcp-remote", "https://gto-thingy.vercel.app/api/mcp"] }
+  }
+}
+```
+
+The hosted instance is a shared, rate-limited best-effort service. For heavy or
+production use, deploy your own (`/api/mcp` on any Vercel deployment of this app) or
+run the local stdio server below.
+
+### Local — stdio
+
+Run the server straight from a clone (no deployment, native inference):
+
+```bash
+pnpm mcp          # speaks MCP over stdio
+```
+
+Register it with your agent. **Claude Code** users get it automatically from the
+checked-in [`.mcp.json`](.mcp.json); for **Claude Desktop** (`claude_desktop_config.json`)
+or any other client, add:
+
+```json
+{
+  "mcpServers": {
+    "gto-lab": { "command": "pnpm", "args": ["mcp"], "cwd": "/absolute/path/to/gto-lab" }
+  }
+}
+```
+
 ## The solver (`solver/`)
 
 The GTO strategy is trained by an external-sampling Deep CFR

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -110,9 +110,11 @@ For stdio-only clients, bridge with [`mcp-remote`](https://www.npmjs.com/package
 
 ## Deploy on Vercel
 
-The remote endpoint is a normal Next route — deploying the app deploys the MCP
-server; connect clients to `https://<deployment>/api/mcp`. Two things make it
-work on serverless, both already configured in `next.config.ts`:
+A hosted instance runs at `https://gto-thingy.vercel.app/api/mcp` — clients can
+connect there directly. To run your own, the remote endpoint is a normal Next
+route, so deploying the app deploys the MCP server; connect clients to
+`https://<deployment>/api/mcp`. Two things make it work on serverless, both
+already configured in `next.config.ts`:
 
 - `serverExternalPackages: ["onnxruntime-web"]` keeps the wasm runtime out of the
   bundler.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -128,6 +128,19 @@ The route pins `runtime = "nodejs"` (never edge — it needs `fs` + WASM) and
 session is cached per warm instance. Transport is stateless (no Redis needed for
 request/response tool calls).
 
+### Rate limiting
+
+The hosted endpoint is protected by a per-IP limit (`src/lib/ratelimit.ts`) via
+[`@upstash/ratelimit`](https://github.com/upstash/ratelimit) over Upstash Redis —
+connectionless HTTP, the standard for Vercel serverless. Default: **30 requests
+per 60 s per IP**, sliding window; over-budget requests get a `429` with
+`Retry-After`.
+
+It is **fail-open**: with no credentials in the environment it is inert and every
+request passes — so local dev, the stdio server, and self-hosters are unaffected.
+To turn it on, create an Upstash Redis DB and set `UPSTASH_REDIS_REST_URL` and
+`UPSTASH_REDIS_REST_TOKEN` (see `.env.example`) in the Vercel project.
+
 > Not yet validated on a live Vercel deploy — the production build traces the
 > three assets correctly and `next start` serves inference identically to dev, so
 > the remaining risk is Vercel-specific. Confirm on first deploy.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,155 @@
+# GTO Lab MCP server
+
+Exposes the GTO Lab solver to AI agents over [MCP](https://modelcontextprotocol.io).
+Two tools, two transports, one set of tool definitions:
+
+- **Local (stdio)** — `mcp/server.ts`, run with `pnpm mcp`. Inference via the
+  native `onnxruntime-node`.
+- **Remote (HTTP)** — `src/app/api/[transport]/route.ts`, served by the Next app
+  at `/api/mcp`. Inference via `onnxruntime-web/wasm` (no native addon), so it
+  deploys on stock Vercel.
+
+Both call `registerGtoTools` from `mcp/tools.ts` and produce **byte-identical**
+strategy (the two ONNX runtimes agree to ~3e-8). All poker logic reuses the
+parity-tested engine in `src/lib/gto/`, so the server never re-implements rules.
+
+Prototype status: two tools. The stdio server runs under `tsx` (no build step);
+the HTTP route is part of the normal Next build.
+
+## Tools
+
+Both tools take a **friendly layer** (cards + a plain-English action line) and a
+**raw layer** (the engine's internal token `History`) for power use / debugging.
+
+Conventions: heads-up, 100bb default. Seat 0 = SB/BTN (in position postflop,
+first to act preflop), seat 1 = BB. Bet abstraction is ½-pot / pot / 2×-pot /
+all-in with a 3-raise cap per street — a numeric bet size in the line is snapped
+to the nearest legal discrete size.
+
+### `get_gto_strategy`
+
+The Nash action distribution at one hero decision. The queried node must be the
+hero's turn.
+
+```jsonc
+// input (friendly)
+{
+  "hero": "As Ks",
+  "position": "SB",
+  "board": "Jh 7c 2s",
+  "line": ["SB raise 3", "BB call", "BB check"]
+}
+// input (raw) — overrides the friendly fields
+{ "history": [51, 50, 12, 25, "c", "b1", "c", 3, 4, 5, "c"], "stack": 200 }
+```
+
+Returns the node context (street, pot, to-call, hero cards, readable line) and a
+`strategy` array of `{ action, token, probability }` over the legal actions.
+
+### `get_range_grid`
+
+The full 13×13 starting-hand range for the player to act after a **public** line
+(no hero cards) — the same computation behind the app's range explorer.
+
+```jsonc
+// input (friendly)
+{ "board": "", "line": ["SB raise 3"] }        // BB's response range vs an open
+// input (raw)
+{ "tokens": ["b1"], "stack": 200 }
+```
+
+Returns node context, the legal `actions` (token + label), the combo-weighted
+`aggregate` mix, and `hands`: each of the 169 classes (fully-blocked ones
+omitted) with its combo count and action mix, aligned to `actions`.
+
+## Run locally
+
+### stdio
+
+```bash
+pnpm mcp          # = tsx mcp/server.ts, speaks MCP over stdio
+```
+
+Register in Claude Desktop (`claude_desktop_config.json`) or Claude Code
+(`.mcp.json` / `claude mcp add`):
+
+```json
+{
+  "mcpServers": {
+    "gto-lab": {
+      "command": "pnpm",
+      "args": ["mcp"],
+      "cwd": "/Users/alfred/pj/gto-lab"
+    }
+  }
+}
+```
+
+### HTTP (against the Next dev server)
+
+```bash
+pnpm dev                                             # serves /api/mcp
+MCP_URL=http://localhost:3000/api/mcp pnpm tsx mcp/http-test.ts
+```
+
+A Streamable-HTTP-capable client connects directly:
+
+```json
+{ "mcpServers": { "gto-lab": { "url": "http://localhost:3000/api/mcp" } } }
+```
+
+For stdio-only clients, bridge with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
+
+```json
+{
+  "mcpServers": {
+    "gto-lab": { "command": "npx", "args": ["mcp-remote", "http://localhost:3000/api/mcp"] }
+  }
+}
+```
+
+## Deploy on Vercel
+
+The remote endpoint is a normal Next route — deploying the app deploys the MCP
+server; connect clients to `https://<deployment>/api/mcp`. Two things make it
+work on serverless, both already configured in `next.config.ts`:
+
+- `serverExternalPackages: ["onnxruntime-web"]` keeps the wasm runtime out of the
+  bundler.
+- `outputFileTracingIncludes` ships the model (`public/models/holdem_strategy.onnx`)
+  and the wasm runtime (`public/ort/*`) into the function, since the route reads
+  them by filesystem path. (`scripts/copy-ort-wasm.mjs`, run on `prepare`/`build`,
+  stages `public/ort/`.)
+
+The route pins `runtime = "nodejs"` (never edge — it needs `fs` + WASM) and
+`maxDuration = 60`. Cold starts load a ~13MB wasm runtime + <1MB model; the
+session is cached per warm instance. Transport is stateless (no Redis needed for
+request/response tool calls).
+
+> Not yet validated on a live Vercel deploy — the production build traces the
+> three assets correctly and `next start` serves inference identically to dev, so
+> the remaining risk is Vercel-specific. Confirm on first deploy.
+
+## Files
+
+| File | Role |
+|---|---|
+| `tools.ts` | shared tool definitions — `registerGtoTools(server, runBatch)` |
+| `notation.ts` | friendly ↔ internal `History` translation (the parser) |
+| `strategy-core.ts` | clip/normalize readout over an injected `BatchRunner` |
+| `runner-node.ts` | `onnxruntime-node` runner (stdio) |
+| `runner-wasm.ts` | `onnxruntime-web/wasm` runner (HTTP / Vercel) |
+| `server.ts` | stdio transport wiring |
+| `smoke.ts` | direct-library usage example (`tsx mcp/smoke.ts`) |
+| `client-test.ts` | stdio MCP round-trip example |
+| `http-test.ts` | HTTP MCP round-trip example |
+
+The HTTP route lives at `src/app/api/[transport]/route.ts` (the `[transport]`
+segment lets one file serve both `/api/mcp` and `/api/sse`).
+
+## Not covered (natural next steps)
+
+- `get_equity_vs_range`, `evaluate_hand`, `generate_practice_spot` — the library
+  functions already exist (`heroEquityVsRange`, `evaluate7`, `generateScenario`).
+- Auth / rate-limiting on the public HTTP endpoint, and packaging the stdio
+  server as an `npx`-able bin.

--- a/mcp/client-test.ts
+++ b/mcp/client-test.ts
@@ -1,0 +1,64 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function main() {
+  const transport = new StdioClientTransport({
+    command: "node_modules/.bin/tsx",
+    args: ["mcp/server.ts"],
+  });
+  const client = new Client({ name: "test", version: "0" });
+  await client.connect(transport);
+
+  const tools = await client.listTools();
+  console.log("TOOLS:", tools.tools.map((t) => t.name).join(", "));
+
+  const r1 = await client.callTool({
+    name: "get_gto_strategy",
+    arguments: {
+      hero: "As Ks",
+      position: "SB",
+      board: "Jh 7c 2s",
+      line: ["SB raise 3", "BB call", "BB check"],
+    },
+  });
+  console.log("\n=== get_gto_strategy ===");
+  console.log((r1.content as { text: string }[])[0].text);
+
+  const r2 = await client.callTool({
+    name: "get_range_grid",
+    arguments: { line: ["SB raise 3"] },
+  });
+  const grid = JSON.parse((r2.content as { text: string }[])[0].text);
+  console.log("\n=== get_range_grid (BB facing SB open) ===");
+  console.log("node:", JSON.stringify(grid.node));
+  console.log(
+    "actions:",
+    grid.actions.map((a: { label: string }) => a.label).join(" | "),
+  );
+  console.log("aggregate:", grid.aggregate);
+  console.log("hands returned:", Object.keys(grid.hands).length);
+  console.log(
+    "AA:",
+    JSON.stringify(grid.hands.AA),
+    " 72o:",
+    JSON.stringify(grid.hands["72o"]),
+  );
+
+  // Error path: ask a node that is the villain's turn.
+  try {
+    await client.callTool({
+      name: "get_gto_strategy",
+      arguments: { hero: "As Ks", position: "BB", line: ["SB raise 3"] },
+    });
+    console.log("\nERROR PATH: (no error thrown?)");
+  } catch (e) {
+    console.log("\nError path OK:", (e as Error).message.slice(0, 120));
+  }
+
+  await client.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/mcp/http-test.ts
+++ b/mcp/http-test.ts
@@ -1,0 +1,58 @@
+/**
+ * Exercises the remote MCP endpoint over Streamable HTTP, the way a real client
+ * (Claude, etc.) would. Point it at a running server: `next dev` locally or a
+ * deployed URL. Usage: MCP_URL=http://localhost:3210/api/mcp tsx mcp/http-test.ts
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const url = process.env.MCP_URL ?? "http://localhost:3210/api/mcp";
+
+async function main() {
+  const transport = new StreamableHTTPClientTransport(new URL(url));
+  const client = new Client({ name: "http-test", version: "0" });
+  await client.connect(transport);
+  console.log("connected to", url);
+
+  const tools = await client.listTools();
+  console.log("TOOLS:", tools.tools.map((t) => t.name).join(", "));
+
+  const r1 = await client.callTool({
+    name: "get_gto_strategy",
+    arguments: {
+      hero: "As Ks",
+      position: "SB",
+      board: "Jh 7c 2s",
+      line: ["SB raise 3", "BB call", "BB check"],
+    },
+  });
+  console.log("\n=== get_gto_strategy (wasm inference) ===");
+  console.log((r1.content as { text: string }[])[0].text);
+
+  const r2 = await client.callTool({
+    name: "get_range_grid",
+    arguments: { line: ["SB raise 3"] },
+  });
+  const grid = JSON.parse((r2.content as { text: string }[])[0].text);
+  console.log("\n=== get_range_grid (BB vs SB open) ===");
+  console.log("node:", JSON.stringify(grid.node));
+  console.log(
+    "aggregate:",
+    grid.aggregate,
+    "| hands:",
+    Object.keys(grid.hands).length,
+  );
+  console.log(
+    "AA:",
+    JSON.stringify(grid.hands.AA),
+    "72o:",
+    JSON.stringify(grid.hands["72o"]),
+  );
+
+  await client.close();
+}
+
+main().catch((e) => {
+  console.error("HTTP test failed:", e?.message ?? e);
+  process.exit(1);
+});

--- a/mcp/notation.test.ts
+++ b/mcp/notation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the friendly ↔ internal `History` translation — the only new
+ * game-facing code in the MCP surface, and the part most likely to
+ * mistranslate an agent's input. Pure logic, no ONNX or network.
+ */
+
+import { STACK, currentPlayer, parseHistory } from "../src/lib/gto/holdem";
+import {
+  buildHistory,
+  buildPublicTokens,
+  cardToStr,
+  parseCard,
+  parseCards,
+  parseSeat,
+  resolveActionToken,
+} from "./notation";
+
+describe("card parsing", () => {
+  test.each([
+    ["Ac", 12], // ace of clubs: suit 0 * 13 + rank 12
+    ["2c", 0], // deuce of clubs: the zero card
+    ["As", 51], // ace of spades: suit 3 * 13 + rank 12
+    ["Kd", 24], // king of diamonds: suit 1 * 13 + rank 11
+    ["Th", 34], // ten of hearts: suit 2 * 13 + rank 8
+  ])('parseCard("%s") === %i', (raw, expected) => {
+    expect(parseCard(raw)).toBe(expected);
+  });
+
+  test("is case-insensitive and accepts 10 for T", () => {
+    expect(parseCard("as")).toBe(parseCard("As"));
+    expect(parseCard("10d")).toBe(parseCard("Td"));
+  });
+
+  test("round-trips through cardToStr", () => {
+    for (let c = 0; c < 52; c++) expect(parseCard(cardToStr(c))).toBe(c);
+  });
+
+  test("rejects bad rank / suit", () => {
+    expect(() => parseCard("Xs")).toThrow(/rank/);
+    expect(() => parseCard("Az")).toThrow(/suit/);
+  });
+
+  test("parseCards splits spaces, commas, and packed strings", () => {
+    const expected = [parseCard("Jh"), parseCard("7c"), parseCard("2s")];
+    expect(parseCards("Jh 7c 2s")).toEqual(expected);
+    expect(parseCards("Jh,7c,2s")).toEqual(expected);
+    expect(parseCards("Jh7c2s")).toEqual(expected);
+    expect(parseCards(["Jh", "7c", "2s"])).toEqual(expected);
+    expect(parseCards(undefined)).toEqual([]);
+    expect(parseCards("")).toEqual([]);
+  });
+});
+
+describe("parseSeat", () => {
+  test.each([
+    ["SB", 0],
+    ["btn", 0],
+    ["Button", 0],
+    ["BB", 1],
+    ["big blind", 1],
+    [0, 0],
+    [1, 1],
+  ])("parseSeat(%s) === %i", (raw, expected) => {
+    expect(parseSeat(raw as string | number)).toBe(expected);
+  });
+
+  test("throws on missing / unrecognized", () => {
+    expect(() => parseSeat(undefined)).toThrow();
+    expect(() => parseSeat("cutoff")).toThrow(/position/);
+  });
+});
+
+describe("resolveActionToken", () => {
+  // Preflop, SB to act — the canonical first decision. Placeholder holes.
+  const preflop = [51, 50, 24, 23];
+
+  test("maps keyword actions", () => {
+    expect(resolveActionToken("check/call", preflop, STACK)).toBe("c");
+    expect(resolveActionToken("call", preflop, STACK)).toBe("c");
+    expect(resolveActionToken("jam", preflop, STACK)).toBe("a");
+    expect(resolveActionToken("all-in", preflop, STACK)).toBe("a");
+  });
+
+  test("fold is illegal when nothing is owed (SB can complete)", () => {
+    // Preflop SB faces the BB, so fold *is* legal here; test an illegal fold
+    // after a check instead: on the flop, first to act cannot fold.
+    const flop = [51, 50, 24, 23, "c", "c", 0, 1, 2];
+    expect(() => resolveActionToken("fold", flop, STACK)).toThrow(/illegal/);
+  });
+
+  test("maps size words to the discrete sizes", () => {
+    expect(resolveActionToken("bet half pot", preflop, STACK)).toBe("b0");
+    expect(resolveActionToken("raise pot", preflop, STACK)).toBe("b1");
+    expect(resolveActionToken("overbet", preflop, STACK)).toBe("b2");
+  });
+
+  test("snaps a numeric BB size to the nearest legal size", () => {
+    // Legal preflop raise amounts (BB): b0=2, b1=3, b2=5 (see engine).
+    expect(resolveActionToken("raise 2", preflop, STACK)).toBe("b0");
+    expect(resolveActionToken("raise to 3", preflop, STACK)).toBe("b1");
+    expect(resolveActionToken("raise 6", preflop, STACK)).toBe("b2"); // nearest to 5
+  });
+
+  test("check keyword is not swallowed by a stray number", () => {
+    expect(resolveActionToken("BB check 0", preflop, STACK)).toBe("c");
+  });
+});
+
+describe("buildHistory", () => {
+  test("places hero cards in the hero's slot and fills the villain", () => {
+    const { history, heroSeat } = buildHistory({
+      hero: "As Ks",
+      heroSeat: 0,
+      stack: STACK,
+    });
+    expect(heroSeat).toBe(0);
+    expect(history[0]).toBe(parseCard("As"));
+    expect(history[1]).toBe(parseCard("Ks"));
+    // villain slots are distinct placeholder cards
+    expect(history[2]).not.toBe(history[0]);
+    expect(currentPlayer(history)).toBe(0); // preflop, SB to act
+  });
+
+  test("interleaves the board into the line at street boundaries", () => {
+    const { history } = buildHistory({
+      hero: "Ah Kd",
+      heroSeat: 0,
+      board: "Jh 7c 2s",
+      line: ["SB raise 3", "BB call", "BB check"],
+      stack: STACK,
+    });
+    const s = parseHistory(history, STACK);
+    expect(s.street).toBe(1); // flop
+    expect(s.board).toEqual([
+      parseCard("Jh"),
+      parseCard("7c"),
+      parseCard("2s"),
+    ]);
+    expect(s.status).toBe("act"); // stopped at a decision node
+    expect(s.toAct).toBe(0); // SB acts first postflop after BB checks
+  });
+
+  test("rejects two-card hero of wrong length", () => {
+    expect(() =>
+      buildHistory({ hero: "As", heroSeat: 0, stack: STACK }),
+    ).toThrow();
+  });
+
+  test("errors when the line needs board cards that weren't given", () => {
+    expect(() =>
+      buildHistory({
+        hero: "Ah Kd",
+        heroSeat: 0,
+        line: ["SB raise 3", "BB call", "BB check"], // reaches the flop
+        stack: STACK, // ...but no board supplied
+      }),
+    ).toThrow(/board/);
+  });
+
+  test("errors when the line runs past the end of the hand", () => {
+    expect(() =>
+      buildHistory({
+        hero: "Ah Kd",
+        heroSeat: 0,
+        line: ["SB fold", "BB check"], // fold ends the hand
+        stack: STACK,
+      }),
+    ).toThrow(/past the end/);
+  });
+});
+
+describe("buildPublicTokens", () => {
+  test("produces board+action tokens with no hole cards", () => {
+    const tokens = buildPublicTokens({ line: ["SB raise 3"], stack: STACK });
+    // first token is the SB's raise, since holes are stripped
+    expect(tokens[0]).toBe("b1");
+  });
+});

--- a/mcp/notation.ts
+++ b/mcp/notation.ts
@@ -1,0 +1,255 @@
+/**
+ * Translation between agent-friendly poker notation and the internal token
+ * `History` the engine (src/lib/gto/holdem.ts) speaks. This is the whole
+ * reason the MCP surface is usable: agents send cards like "As Kd", a board,
+ * and a plain-English action line; this module turns that into a valid
+ * History, and turns engine tokens back into readable labels.
+ *
+ * Card ints match the engine: rank = card % 13 (0 = deuce .. 12 = ace),
+ * suit = floor(card / 13), order clubs(0) diamonds(1) hearts(2) spades(3).
+ */
+
+import {
+  ALL_IN,
+  CHECK_CALL,
+  FOLD,
+  type History,
+  type HistoryToken,
+  aggressiveAmounts,
+  isChance,
+  isTerminal,
+  legalActions,
+  parseHistory,
+} from "../src/lib/gto/holdem";
+
+const RANK_CHARS = "23456789TJQKA";
+const SUIT_CHARS = "cdhs"; // clubs, diamonds, hearts, spades — engine order
+
+/** Parse a single card like "As", "Td", "9h" (case-insensitive) to 0..51. */
+export function parseCard(raw: string): number {
+  const t = raw.trim();
+  if (t.length < 2) throw new Error(`bad card "${raw}"`);
+  // Rank may be one char (A,K,…,2) or the word "10".
+  const rankStr = t
+    .slice(0, t.length - 1)
+    .toUpperCase()
+    .replace("10", "T");
+  const suitStr = t[t.length - 1].toLowerCase();
+  const rank = RANK_CHARS.indexOf(rankStr);
+  const suit = SUIT_CHARS.indexOf(suitStr);
+  if (rank < 0) throw new Error(`bad rank in "${raw}" (use 2-9,T,J,Q,K,A)`);
+  if (suit < 0) throw new Error(`bad suit in "${raw}" (use c,d,h,s)`);
+  return suit * 13 + rank;
+}
+
+/** Parse "As Kd" / "Jh7c2s" / ["Jh","7c","2s"] to card ints. */
+export function parseCards(raw: string | string[] | undefined): number[] {
+  if (!raw) return [];
+  const parts = Array.isArray(raw)
+    ? raw
+    : raw.trim().length === 0
+      ? []
+      : // split on whitespace/commas, or pack of 2-char cards ("Jh7c2s")
+        (raw.match(/10[cdhs]|[2-9TJQKAtjqka][cdhs]/gi) ??
+        raw.split(/[\s,]+/).filter(Boolean));
+  return parts.map(parseCard);
+}
+
+export function cardToStr(c: number): string {
+  return `${RANK_CHARS[c % 13]}${SUIT_CHARS[Math.floor(c / 13)]}`;
+}
+
+/**
+ * Resolve one action-line entry (e.g. "BB raise 6", "check", "jam") to a legal
+ * token at the current node. Position/actor words are ignored — the engine
+ * already knows whose turn it is. A numeric bet size is snapped to the nearest
+ * legal discrete size (the solver only knows ½-pot, pot, 2×pot, all-in), and a
+ * size word (half/pot/overbet/all-in) maps directly.
+ */
+export function resolveActionToken(
+  entry: string,
+  h: History,
+  stack: number,
+): HistoryToken {
+  const s = entry.toLowerCase();
+  const legal = new Set(legalActions(h, stack));
+
+  const want = (tok: string): HistoryToken => {
+    if (!legal.has(tok)) {
+      throw new Error(
+        `"${entry}" resolves to ${tok}, illegal here (legal: ${[...legal].join(", ")})`,
+      );
+    }
+    return tok;
+  };
+
+  if (/\bfold\b|^f$/.test(s)) return want(FOLD);
+  if (/\ball[\s-]?in\b|\bjam\b|\bshove\b|^a$/.test(s)) return want(ALL_IN);
+  // check/call before bet/raise so "check" isn't caught by a stray number.
+  if (/\bcheck\b|\bcall\b|^c$/.test(s)) return want(CHECK_CALL);
+
+  // Bet or raise: figure out which discrete size.
+  const amounts = aggressiveAmounts(parseHistory(h, stack)); // token -> chip amt
+  const aggTokens = Object.keys(amounts);
+  if (aggTokens.length === 0) {
+    throw new Error(`"${entry}" is a bet/raise but none is legal here`);
+  }
+  if (/\bover\b|\boverbet\b|2x|2 x|double/.test(s)) return want("b2");
+  if (/half|1\/2|½/.test(s)) return want("b0");
+  // "pot" (but not "half pot", handled above) maps to the pot-sized bet.
+  if (/\bpot\b/.test(s) && amounts.b1 !== undefined) return want("b1");
+
+  // Numeric size in big blinds -> nearest legal size (amounts are in 0.5bb).
+  const num = s.match(/(\d+(?:\.\d+)?)/);
+  if (num) {
+    const targetBB = Number.parseFloat(num[1]);
+    let best = aggTokens[0];
+    let bestDiff = Number.POSITIVE_INFINITY;
+    for (const tok of aggTokens) {
+      const diff = Math.abs(amounts[tok] / 2 - targetBB);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = tok;
+      }
+    }
+    return want(best);
+  }
+
+  // Bare "bet"/"raise" with no size: default to a pot-sized bet if available,
+  // else the smallest legal aggressive size.
+  return want(amounts.b1 !== undefined ? "b1" : aggTokens[0]);
+}
+
+/** Two/four distinct placeholder cards not colliding with `dead`. */
+function placeholders(dead: Set<number>, count: number): number[] {
+  const out: number[] = [];
+  for (let c = 0; c < 52 && out.length < count; c++) {
+    if (!dead.has(c)) {
+      out.push(c);
+      dead.add(c);
+    }
+  }
+  return out;
+}
+
+export interface FriendlySpot {
+  hero: string | string[];
+  /** 0 = Button/SB, 1 = Big Blind. Accepts a string form via parseSeat. */
+  heroSeat: number;
+  board?: string | string[];
+  line?: string | string[];
+  stack: number;
+}
+
+/** "SB"/"BTN"/"button"/"0" -> 0 ; "BB"/"bigblind"/"1" -> 1. */
+export function parseSeat(raw: string | number | undefined): number {
+  if (raw === undefined) throw new Error("heroSeat/position is required");
+  if (typeof raw === "number") return raw === 1 ? 1 : 0;
+  const s = raw.toLowerCase();
+  if (/bb|big/.test(s) || s === "1") return 1;
+  if (/sb|btn|button|small|^0$/.test(s)) return 0;
+  throw new Error(`unrecognized position "${raw}" (use SB/BTN or BB)`);
+}
+
+function normalizeLine(line: string | string[] | undefined): string[] {
+  if (!line) return [];
+  if (Array.isArray(line)) return line.filter((e) => e.trim().length > 0);
+  return line
+    .split(/[,;]/)
+    .map((e) => e.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Build the full History for a hero decision: hero cards in the hero's slot,
+ * placeholders for the villain (whose cards never enter the acting player's
+ * infoset), and the board interleaved into the action line at street
+ * boundaries by replaying through the engine. Stops at the node reached after
+ * the last action-line entry, which is the node to be queried.
+ */
+export function buildHistory(spot: FriendlySpot): {
+  history: History;
+  heroSeat: number;
+} {
+  const heroCards = parseCards(spot.hero);
+  if (heroCards.length !== 2) {
+    throw new Error('hero must be exactly two cards, e.g. "As Kd"');
+  }
+  const board = parseCards(spot.board);
+  const line = normalizeLine(spot.line);
+  const heroSeat = spot.heroSeat;
+  const stack = spot.stack;
+
+  const dead = new Set<number>([...heroCards, ...board]);
+  const villain = placeholders(dead, 2);
+
+  const h: History =
+    heroSeat === 0
+      ? [heroCards[0], heroCards[1], villain[0], villain[1]]
+      : [villain[0], villain[1], heroCards[0], heroCards[1]];
+
+  let bi = 0;
+  let ti = 0;
+  for (;;) {
+    if (isChance(h, stack)) {
+      if (bi >= board.length) {
+        throw new Error(
+          "the action line reaches a new street but not enough board cards were given",
+        );
+      }
+      h.push(board[bi++]);
+      continue;
+    }
+    if (isTerminal(h, stack)) {
+      if (ti < line.length) {
+        throw new Error("the action line continues past the end of the hand");
+      }
+      break;
+    }
+    if (ti >= line.length) break; // reached the node to query
+    h.push(resolveActionToken(line[ti++], h, stack));
+  }
+  return { history: h, heroSeat };
+}
+
+/**
+ * Build the *public* token list (board + actions, no hole cards) that
+ * computeRangeGrid expects, from a friendly board + line. Uses placeholder
+ * holes only to replay streets, then strips them.
+ */
+export function buildPublicTokens(spot: {
+  board?: string | string[];
+  line?: string | string[];
+  stack: number;
+}): HistoryToken[] {
+  const board = parseCards(spot.board);
+  const line = normalizeLine(spot.line);
+  const stack = spot.stack;
+
+  const dead = new Set<number>(board);
+  const holes = placeholders(dead, 4);
+  const h: History = [holes[0], holes[1], holes[2], holes[3]];
+
+  let bi = 0;
+  let ti = 0;
+  for (;;) {
+    if (isChance(h, stack)) {
+      if (bi >= board.length) {
+        throw new Error(
+          "the action line reaches a new street but not enough board cards were given",
+        );
+      }
+      h.push(board[bi++]);
+      continue;
+    }
+    if (isTerminal(h, stack)) {
+      if (ti < line.length) {
+        throw new Error("the action line continues past the end of the hand");
+      }
+      break;
+    }
+    if (ti >= line.length) break;
+    h.push(resolveActionToken(line[ti++], h, stack));
+  }
+  return h.slice(4);
+}

--- a/mcp/runner-node.ts
+++ b/mcp/runner-node.ts
@@ -1,0 +1,39 @@
+/**
+ * Native-addon inference runner (onnxruntime-node) for the local stdio server.
+ * Fast to start and simple, but a native binary — which is why the remote
+ * Next/Vercel path uses the wasm runner (runner-wasm.ts) instead. Both expose
+ * the same `BatchRunner` signature from src/lib/gto/ranges.ts, so the shared
+ * tools in tools.ts run over either.
+ *
+ * This is the same runtime scripts/check-onnx-runtime.mjs uses to validate the
+ * shipped artifact; graph-execution semantics are provider-agnostic, so its
+ * logits match the browser's wasm runtime bit-for-bit.
+ */
+
+import { fileURLToPath } from "node:url";
+import * as ort from "onnxruntime-node";
+import { FEATURE_DIM } from "../src/lib/gto/holdem";
+
+const MODEL_PATH = fileURLToPath(
+  new URL("../public/models/holdem_strategy.onnx", import.meta.url),
+);
+
+let sessionPromise: Promise<ort.InferenceSession> | null = null;
+
+function session(): Promise<ort.InferenceSession> {
+  if (!sessionPromise) {
+    sessionPromise = ort.InferenceSession.create(MODEL_PATH);
+  }
+  return sessionPromise;
+}
+
+/** Raw action logits for a batch of feature rows (rows x MAX_ACTIONS). */
+export async function runStrategyBatch(
+  features: Float32Array,
+  rows: number,
+): Promise<Float32Array> {
+  const s = await session();
+  const input = new ort.Tensor("float32", features, [rows, FEATURE_DIM]);
+  const output = await s.run({ features: input });
+  return output.action_logits.data as Float32Array;
+}

--- a/mcp/runner-wasm.ts
+++ b/mcp/runner-wasm.ts
@@ -1,0 +1,55 @@
+/**
+ * WASM inference runner (onnxruntime-web/wasm) for the remote Next/Vercel MCP
+ * route. Pure WebAssembly — no native addon — so it deploys on standard
+ * serverless functions where onnxruntime-node's `.node` binary is a liability.
+ * Proven bit-identical to the native runner (diff ~3e-8), because ONNX graph
+ * execution is provider-agnostic.
+ *
+ * The model bytes and the wasm runtime are read from the filesystem rather than
+ * fetched, so nothing depends on the deployment URL. On Vercel both are shipped
+ * into the function bundle via next.config `outputFileTracingIncludes`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as ort from "onnxruntime-web/wasm";
+import { FEATURE_DIM } from "../src/lib/gto/holdem";
+
+/**
+ * The wasm runtime and the model are read by runtime filesystem path (not a
+ * bundler-resolved import), so Turbopack/webpack never tries to inline them.
+ * Both live under public/ — the wasm files are staged there by
+ * scripts/copy-ort-wasm.mjs — and are traced into the Vercel function by
+ * next.config `outputFileTracingIncludes`.
+ */
+function publicPath(...parts: string[]): string {
+  return join(process.cwd(), "public", ...parts);
+}
+
+let sessionPromise: Promise<ort.InferenceSession> | null = null;
+
+function session(): Promise<ort.InferenceSession> {
+  if (!sessionPromise) {
+    // Trailing slash: onnxruntime-web treats wasmPaths as a prefix.
+    ort.env.wasm.wasmPaths = `${publicPath("ort")}/`;
+    ort.env.wasm.numThreads = 1; // single-threaded: no worker pool in serverless
+    const bytes = new Uint8Array(
+      readFileSync(publicPath("models", "holdem_strategy.onnx")),
+    );
+    sessionPromise = ort.InferenceSession.create(bytes, {
+      executionProviders: ["wasm"],
+    });
+  }
+  return sessionPromise;
+}
+
+/** Raw action logits for a batch of feature rows (rows x MAX_ACTIONS). */
+export async function runStrategyBatch(
+  features: Float32Array,
+  rows: number,
+): Promise<Float32Array> {
+  const s = await session();
+  const input = new ort.Tensor("float32", features, [rows, FEATURE_DIM]);
+  const output = await s.run({ features: input });
+  return output.action_logits.data as Float32Array;
+}

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1,0 +1,28 @@
+/**
+ * Local MCP stdio server exposing the GTO Lab solver to AI agents. Registers
+ * the shared tools (mcp/tools.ts) over the native onnxruntime-node runner.
+ * The remote HTTP equivalent lives in src/app/api/[transport]/route.ts and
+ * shares the exact same tool definitions.
+ *
+ * Run: `pnpm mcp`
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { runStrategyBatch } from "./runner-node";
+import { registerGtoTools } from "./tools";
+
+async function main() {
+  const server = new McpServer({ name: "gto-lab", version: "0.1.0" });
+  registerGtoTools(server, runStrategyBatch);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // stderr is safe; stdout is the JSON-RPC channel.
+  process.stderr.write("gto-lab MCP server ready (stdio)\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`fatal: ${err?.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/mcp/smoke.ts
+++ b/mcp/smoke.ts
@@ -1,0 +1,80 @@
+import { ACTION_INDEX, STACK, currentPlayer } from "../src/lib/gto/holdem";
+import { computeRangeGrid, nodeSummary } from "../src/lib/gto/ranges";
+import { describeSpot } from "../src/lib/gto/strategy";
+import { buildHistory, buildPublicTokens } from "./notation";
+import { runStrategyBatch } from "./runner-node";
+import { getStrategy } from "./strategy-core";
+
+async function main() {
+  // 1) Preflop: hero BTN/SB with AKs, first decision.
+  {
+    const { history, heroSeat } = buildHistory({
+      hero: "As Ks",
+      heroSeat: 0,
+      stack: STACK,
+    });
+    const probs = await getStrategy(runStrategyBatch, history, STACK);
+    const info = describeSpot(history, heroSeat, STACK);
+    console.log("[1] Preflop AKs SB open:");
+    console.log("    seat", heroSeat, "toAct", currentPlayer(history));
+    for (const p of probs)
+      console.log(
+        `    ${info.actionLabels[p.action]}: ${(p.probability * 100).toFixed(1)}%`,
+      );
+  }
+
+  // 2) A postflop line: SB opens, BB calls, flop, BB checks -> SB to act.
+  {
+    const { history, heroSeat } = buildHistory({
+      hero: "Ah Kd",
+      heroSeat: 0,
+      board: "Jh 7c 2s",
+      line: ["SB raise 6", "BB call", "BB check"],
+      stack: STACK,
+    });
+    const probs = await getStrategy(runStrategyBatch, history, STACK);
+    const info = describeSpot(history, heroSeat, STACK);
+    console.log("\n[2] Flop Jh7c2s, AKo SB after BB check:");
+    console.log(
+      "    pot",
+      info.potBB,
+      "toCall",
+      info.toCallBB,
+      "line",
+      info.lineDescription,
+    );
+    console.log("    toAct seat", currentPlayer(history), "hero", heroSeat);
+    for (const p of probs)
+      console.log(
+        `    ${info.actionLabels[p.action]}: ${(p.probability * 100).toFixed(1)}%`,
+      );
+  }
+
+  // 3) Range grid: preflop, SB to act (empty line).
+  {
+    const tokens = buildPublicTokens({ stack: STACK });
+    const grid = await computeRangeGrid(tokens, runStrategyBatch, ACTION_INDEX);
+    const sum = nodeSummary(tokens);
+    console.log("\n[3] Preflop range grid, acting seat", sum.actingSeat);
+    console.log("    actions", grid.actions);
+    console.log(
+      "    aggregate",
+      grid.aggregate.map((v) => v.toFixed(3)),
+    );
+    const show = (label: string) => {
+      const c = grid.cells.find((x) => x.label === label);
+      console.log(
+        `    ${label}: ${c?.probs?.map((v) => v.toFixed(2)).join(" / ")}`,
+      );
+    };
+    show("AA");
+    show("AKs");
+    show("72o");
+    show("K9o");
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/mcp/strategy-core.ts
+++ b/mcp/strategy-core.ts
@@ -1,0 +1,44 @@
+/**
+ * The strategy-net readout, factored out of the browser-bound getStrategy in
+ * src/lib/gto/strategy.ts so it can run over any `BatchRunner` (native or
+ * wasm). Identical clip-and-normalize (uniform fallback when a row has no
+ * positive legal logit) — the same rule the range grid and the LBR exploiter
+ * use.
+ */
+
+import {
+  ACTION_INDEX,
+  type History,
+  STACK,
+  infosetFeatures,
+  legalActions,
+} from "../src/lib/gto/holdem";
+import type { BatchRunner } from "../src/lib/gto/ranges";
+
+export interface ActionProb {
+  action: string;
+  probability: number;
+}
+
+/** GTO action distribution at a decision node (legal actions only). */
+export async function getStrategy(
+  runBatch: BatchRunner,
+  h: History,
+  stack: number = STACK,
+): Promise<ActionProb[]> {
+  const features = infosetFeatures(h, stack);
+  const logits = await runBatch(features, 1);
+  const actions = legalActions(h, stack);
+  const clipped = actions.map((a) => Math.max(logits[ACTION_INDEX[a]], 0));
+  const total = clipped.reduce((s, v) => s + v, 0);
+  if (total <= 0) {
+    return actions.map((action) => ({
+      action,
+      probability: 1 / actions.length,
+    }));
+  }
+  return actions.map((action, i) => ({
+    action,
+    probability: clipped[i] / total,
+  }));
+}

--- a/mcp/tools.test.ts
+++ b/mcp/tools.test.ts
@@ -1,0 +1,139 @@
+/**
+ * End-to-end test of the MCP tool surface over the SDK's in-memory transport:
+ * a real McpServer + Client talking JSON-RPC, exercising the actual tool
+ * handlers (notation → strategy readout → formatting). Inference is a fake
+ * deterministic runner injected via `registerGtoTools`, so these assertions are
+ * stable and need no ONNX — the model itself is validated separately by
+ * `pnpm check:onnx`.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MAX_ACTIONS } from "../src/lib/gto/holdem";
+import type { BatchRunner } from "../src/lib/gto/ranges";
+import { registerGtoTools } from "./tools";
+
+/**
+ * Fake runner returning a fixed logit vector per row. b0 (index 2) is largest,
+ * so the strategy leans toward the ½-pot bet — enough to make the normalization
+ * assertions concrete without depending on the trained net.
+ */
+const fakeRunner: BatchRunner = async (_features, rows) => {
+  const out = new Float32Array(rows * MAX_ACTIONS);
+  const pattern = [0, 1, 3, 2, 0.5, 0.5]; // f, c, b0, b1, b2, a
+  for (let r = 0; r < rows; r++) out.set(pattern, r * MAX_ACTIONS);
+  return out;
+};
+
+async function connectedClient(): Promise<Client> {
+  const server = new McpServer({ name: "test", version: "0" });
+  registerGtoTools(server, fakeRunner);
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test", version: "0" });
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return client;
+}
+
+function parse(result: { content: unknown }) {
+  return JSON.parse((result.content as { text: string }[])[0].text);
+}
+
+describe("MCP tools over in-memory transport", () => {
+  let client: Client;
+  beforeAll(async () => {
+    client = await connectedClient();
+  });
+  afterAll(async () => {
+    await client.close();
+  });
+
+  test("both tools are registered", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "get_gto_strategy",
+      "get_range_grid",
+    ]);
+  });
+
+  test("get_gto_strategy returns a normalized mix over legal actions", async () => {
+    const res = await client.callTool({
+      name: "get_gto_strategy",
+      arguments: {
+        hero: "As Ks",
+        position: "SB",
+        board: "Jh 7c 2s",
+        line: ["SB raise 3", "BB call", "BB check"],
+      },
+    });
+    const out = parse(res);
+
+    expect(out.node.street).toBe("Flop");
+    expect(out.node.heroCards).toEqual(["As", "Ks"]);
+    expect(out.node.board).toEqual(["Jh", "7c", "2s"]);
+
+    const total = out.strategy.reduce(
+      (s: number, a: { probability: number }) => s + a.probability,
+      0,
+    );
+    expect(total).toBeCloseTo(1, 5); // probabilities sum to 1
+    // fake logits make b0 (½-pot bet) the modal action
+    const top = [...out.strategy].sort(
+      (a, b) => b.probability - a.probability,
+    )[0];
+    expect(top.token).toBe("b0");
+    // every returned action carries a human label + token
+    for (const a of out.strategy) {
+      expect(a.token).toBeTruthy();
+      expect(a.action).toBeTruthy();
+    }
+  });
+
+  test("get_gto_strategy rejects a node that is the villain's turn", async () => {
+    // Hero is BB, but the empty line stops at the SB's opening decision.
+    const res = await client.callTool({
+      name: "get_gto_strategy",
+      arguments: { hero: "As Ks", position: "BB", line: [] },
+    });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/villain's turn/);
+  });
+
+  test("get_gto_strategy errors on a line that ends the hand", async () => {
+    const res = await client.callTool({
+      name: "get_gto_strategy",
+      arguments: { hero: "As Ks", position: "SB", line: ["SB fold"] },
+    });
+    expect(res.isError).toBe(true);
+  });
+
+  test("get_range_grid returns all 169 classes with a normalized aggregate", async () => {
+    const res = await client.callTool({
+      name: "get_range_grid",
+      arguments: { line: ["SB raise 3"] },
+    });
+    const out = parse(res);
+
+    expect(out.node.actingPosition).toBe("BB");
+    expect(Object.keys(out.hands)).toHaveLength(169); // no board blockers preflop
+    const aggTotal = out.aggregate.reduce((s: number, v: number) => s + v, 0);
+    expect(aggTotal).toBeCloseTo(1, 5);
+    // each hand's mix aligns with the actions array and sums to 1
+    const nActions = out.actions.length;
+    for (const label of Object.keys(out.hands)) {
+      const mix = out.hands[label].mix;
+      expect(mix).toHaveLength(nActions);
+      expect(mix.reduce((s: number, v: number) => s + v, 0)).toBeCloseTo(1, 4);
+    }
+  });
+
+  test("raw history form bypasses the friendly parser", async () => {
+    const res = await client.callTool({
+      name: "get_gto_strategy",
+      arguments: { history: [51, 50, 24, 23], stack: 200 },
+    });
+    const out = parse(res);
+    expect(out.node.street).toBe("Preflop");
+    expect(out.strategy.length).toBeGreaterThan(0);
+  });
+});

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -1,0 +1,254 @@
+/**
+ * The GTO Lab MCP tool surface, shared by every transport. Both the local
+ * stdio server (mcp/server.ts) and the remote Next/Vercel route
+ * (src/app/api/[transport]/route.ts) call `registerGtoTools` with their own
+ * inference runner — native onnxruntime-node locally, onnxruntime-web/wasm on
+ * the server — so the two deployments expose byte-identical strategy.
+ *
+ * All poker logic reuses the parity-tested engine in src/lib/gto/; this module
+ * only translates friendly input, runs the net, and formats the reply.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  ACTION_INDEX,
+  type History,
+  type HistoryToken,
+  STACK,
+  currentPlayer,
+  isChance,
+  isTerminal,
+  parseHistory,
+} from "../src/lib/gto/holdem";
+import {
+  type BatchRunner,
+  computeRangeGrid,
+  navigationHistory,
+  nodeSummary,
+} from "../src/lib/gto/ranges";
+import { describeSpot } from "../src/lib/gto/strategy";
+import {
+  buildHistory,
+  buildPublicTokens,
+  cardToStr,
+  parseSeat,
+} from "./notation";
+import { getStrategy } from "./strategy-core";
+
+const STREET_NAMES = ["Preflop", "Flop", "Turn", "River"];
+
+/** big blinds -> internal 0.5bb chip units (100bb = STACK = 200 chips). */
+function stackChips(stackBB: number | undefined): number {
+  return stackBB === undefined ? STACK : Math.round(stackBB * 2);
+}
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+/**
+ * Register `get_gto_strategy` and `get_range_grid` on an MCP server. `runBatch`
+ * is the only injected dependency — swap it to change where inference runs.
+ */
+export function registerGtoTools(server: McpServer, runBatch: BatchRunner) {
+  // ---- get_gto_strategy -----------------------------------------------------
+  server.registerTool(
+    "get_gto_strategy",
+    {
+      title: "GTO strategy at a decision",
+      description:
+        "Return the solver's Nash action distribution for a heads-up No-Limit " +
+        "Hold'em decision (100bb default, ½-pot / pot / 2×-pot / all-in bet " +
+        "abstraction). Friendly form: give the hero's two cards, the hero's " +
+        "position (SB/BTN or BB), the board so far, and the action line as plain " +
+        'words (e.g. ["SB raise 6","BB call","BB check"]). Numeric bet sizes ' +
+        "are snapped to the nearest legal discrete size. The queried node must " +
+        "be the hero's turn to act. Raw form: pass the internal token `history`.",
+      inputSchema: {
+        hero: z
+          .string()
+          .optional()
+          .describe(
+            'Hero hole cards, e.g. "As Kd". Required for the friendly form.',
+          ),
+        position: z
+          .string()
+          .optional()
+          .describe('Hero position: "SB"/"BTN" (in position preflop) or "BB".'),
+        board: z
+          .string()
+          .optional()
+          .describe('Community cards so far, e.g. "Jh 7c 2s". Empty preflop.'),
+        line: z
+          .union([z.string(), z.array(z.string())])
+          .optional()
+          .describe(
+            'Action line up to the hero decision, e.g. ["SB raise 6","BB call"]. ' +
+              "Actor/position words are ignored; fold/check/call/bet/raise/all-in " +
+              "and a size (half/pot/overbet/all-in or a BB number) are read.",
+          ),
+        stackBB: z
+          .number()
+          .optional()
+          .describe("Starting stack in big blinds (default 100)."),
+        history: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe(
+            "Raw internal token History (advanced; overrides friendly fields).",
+          ),
+        stack: z
+          .number()
+          .optional()
+          .describe(
+            "Raw effective stack in 0.5bb chip units (advanced; default 200).",
+          ),
+      },
+    },
+    async (args) => {
+      let history: History;
+      let heroSeat: number;
+      let stack: number;
+
+      if (args.history) {
+        history = args.history as History;
+        stack = args.stack ?? STACK;
+        if (isChance(history, stack) || isTerminal(history, stack)) {
+          throw new Error("raw history is not at a decision node");
+        }
+        heroSeat = currentPlayer(history, stack);
+      } else {
+        if (!args.hero)
+          throw new Error('provide "hero" (e.g. "As Kd") or a raw "history"');
+        heroSeat = parseSeat(args.position);
+        stack = stackChips(args.stackBB);
+        history = buildHistory({
+          hero: args.hero,
+          heroSeat,
+          board: args.board,
+          line: args.line,
+          stack,
+        }).history;
+        if (isTerminal(history, stack) || isChance(history, stack)) {
+          throw new Error("the action line does not end on a decision node");
+        }
+        if (currentPlayer(history, stack) !== heroSeat) {
+          throw new Error(
+            "the queried node is the villain's turn, not the hero's — extend the line or check the position",
+          );
+        }
+      }
+
+      const probs = await getStrategy(runBatch, history, stack);
+      const info = describeSpot(history, heroSeat, stack);
+      const heroCards = [
+        cardToStr(history[2 * heroSeat] as number),
+        cardToStr(history[2 * heroSeat + 1] as number),
+      ];
+      const board = parseHistory(history, stack).board.map((c) =>
+        cardToStr(c as number),
+      );
+
+      return textResult({
+        node: {
+          street: info.streetName,
+          potBB: info.potBB,
+          toCallBB: info.toCallBB,
+          heroSeat,
+          heroPosition: heroSeat === 0 ? "SB/BTN" : "BB",
+          heroCards,
+          board,
+          line: info.lineDescription,
+        },
+        strategy: probs.map((p) => ({
+          action: info.actionLabels[p.action] ?? p.action,
+          token: p.action,
+          probability: Number(p.probability.toFixed(4)),
+        })),
+      });
+    },
+  );
+
+  // ---- get_range_grid -------------------------------------------------------
+  server.registerTool(
+    "get_range_grid",
+    {
+      title: "GTO range grid for a public line",
+      description:
+        "Return the full 13x13 starting-hand range for the player to act after " +
+        "a public action line (no hero cards). Each of the 169 hand classes " +
+        "gets its combo-averaged action mix, plus the range-wide aggregate. " +
+        "Friendly form: board + action line as plain words. Raw form: internal " +
+        "`tokens` (board cards + action tokens, no holes).",
+      inputSchema: {
+        board: z
+          .string()
+          .optional()
+          .describe('Community cards, e.g. "Jh 7c 2s". Empty preflop.'),
+        line: z
+          .union([z.string(), z.array(z.string())])
+          .optional()
+          .describe('Public action line, e.g. ["SB raise 6","BB call"].'),
+        stackBB: z
+          .number()
+          .optional()
+          .describe("Starting stack in big blinds (default 100)."),
+        tokens: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe(
+            "Raw public token list (advanced; overrides friendly fields).",
+          ),
+        stack: z
+          .number()
+          .optional()
+          .describe("Raw stack in 0.5bb chip units (advanced)."),
+      },
+    },
+    async (args) => {
+      const stack = args.tokens
+        ? (args.stack ?? STACK)
+        : stackChips(args.stackBB);
+      const tokens: HistoryToken[] = args.tokens
+        ? (args.tokens as HistoryToken[])
+        : buildPublicTokens({ board: args.board, line: args.line, stack });
+
+      const grid = await computeRangeGrid(tokens, runBatch, ACTION_INDEX);
+      const summary = nodeSummary(tokens);
+      const labels = describeSpot(
+        navigationHistory(tokens),
+        summary.actingSeat,
+        stack,
+      ).actionLabels;
+
+      const round = (xs: number[]) => xs.map((v) => Number(v.toFixed(4)));
+      const hands: Record<string, { combos: number; mix: number[] }> = {};
+      for (const cell of grid.cells) {
+        if (cell.combos === 0 || !cell.probs) continue;
+        hands[cell.label] = { combos: cell.combos, mix: round(cell.probs) };
+      }
+
+      return textResult({
+        node: {
+          street: STREET_NAMES[summary.street],
+          potBB: summary.potBB,
+          toCallBB: summary.toCallBB,
+          actingSeat: summary.actingSeat,
+          actingPosition: summary.actingSeat === 0 ? "SB/BTN" : "BB",
+        },
+        actions: grid.actions.map((tok) => ({
+          token: tok,
+          label: labels[tok] ?? tok,
+        })),
+        aggregate: round(grid.aggregate),
+        note: "mix arrays are aligned to `actions`; hands fully blocked by the board are omitted",
+        hands,
+      });
+    },
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  // The remote MCP route (src/app/api/[transport]) runs ONNX inference server-
+  // side through onnxruntime-web/wasm. Keep it un-bundled so its wasm runtime
+  // loads from node_modules on disk instead of being mangled by the bundler.
+  serverExternalPackages: ["onnxruntime-web"],
+  // The route reads the model and the wasm runtime from public/ by runtime
+  // filesystem path, which the tracer can't see — include them explicitly so
+  // they ship in the serverless function bundle on Vercel.
+  outputFileTracingIncludes: {
+    "/api/**": [
+      "./public/models/holdem_strategy.onnx",
+      "./public/ort/ort-wasm-simd-threaded.wasm",
+      "./public/ort/ort-wasm-simd-threaded.mjs",
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "prepare": "node scripts/copy-ort-wasm.mjs"
   },
   "dependencies": {
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "mcp-handler": "1.1.0",
     "next": "16.0.7",
     "onnxruntime-web": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -12,18 +12,22 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "check:onnx": "node scripts/check-onnx-runtime.mjs",
+    "mcp": "tsx mcp/server.ts",
     "prepare": "node scripts/copy-ort-wasm.mjs"
   },
   "dependencies": {
+    "mcp-handler": "1.1.0",
     "next": "16.0.7",
     "onnxruntime-web": "^1.27.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "recharts": "^3.3.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
@@ -36,6 +40,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "onnxruntime-node": "^1.27.0",
     "tailwindcss": "^4",
+    "tsx": "^4.23.1",
     "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "check:onnx": "node scripts/check-onnx-runtime.mjs",
+    "check:mcp": "node scripts/check-mcp.mjs",
     "mcp": "tsx mcp/server.ts",
     "prepare": "node scripts/copy-ort-wasm.mjs"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      mcp-handler:
+        specifier: 1.1.0
+        version: 1.1.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(next@16.0.7(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       next:
         specifier: 16.0.7
         version: 16.0.7(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -23,6 +26,9 @@ importers:
       recharts:
         specifier: ^3.3.0
         version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-is@19.2.7)(react@19.2.0)(redux@5.0.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.8
         version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
@@ -30,6 +36,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.0
         version: 2.2.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.3
@@ -66,6 +75,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.3.3
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -348,6 +360,168 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@2.0.12':
+    resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -621,6 +795,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -716,6 +900,35 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
 
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
@@ -1070,6 +1283,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   adm-zip@0.5.18:
     resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
     engines: {node: '>=12.0'}
@@ -1077,6 +1294,17 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -1152,6 +1380,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
@@ -1168,6 +1400,18 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1187,6 +1431,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -1210,6 +1458,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -1224,11 +1476,39 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1327,6 +1607,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1345,8 +1629,15 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
@@ -1360,6 +1651,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.24.2:
     resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
@@ -1380,12 +1675,24 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
   es-toolkit@1.49.0:
     resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -1400,8 +1707,20 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -1415,11 +1734,31 @@ packages:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  express-rate-limit@8.6.1:
+    resolution: {integrity: sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -1432,6 +1771,14 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1439,6 +1786,13 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1448,9 +1802,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -1490,12 +1852,28 @@ packages:
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.32:
+    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1511,6 +1889,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   immer@11.1.15:
@@ -1540,6 +1922,14 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -1553,6 +1943,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -1725,6 +2118,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.4:
+    resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1748,6 +2144,12 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1866,8 +2268,38 @@ packages:
     resolution: {integrity: sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mcp-handler@1.1.0:
+    resolution: {integrity: sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -1903,6 +2335,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   next@16.0.7:
     resolution: {integrity: sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==}
@@ -1944,9 +2380,21 @@ packages:
   nwsapi@2.2.24:
     resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1991,6 +2439,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2007,6 +2459,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2021,6 +2476,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -2049,12 +2508,28 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -2098,6 +2573,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -2110,6 +2588,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
@@ -2120,6 +2602,10 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -2143,9 +2629,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@8.1.0:
     resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -2158,6 +2655,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -2187,6 +2700,10 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -2276,6 +2793,10 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -2286,6 +2807,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -2299,6 +2825,10 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2306,6 +2836,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -2324,6 +2858,10 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
@@ -2398,6 +2936,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -2409,6 +2950,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
@@ -2708,6 +3257,88 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@hono/node-server@2.0.12(hono@4.12.32)':
+    dependencies:
+      hono: 4.12.32
 
   '@img/colour@1.1.0':
     optional: true
@@ -3033,6 +3664,28 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.0.12(hono@4.12.32)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.1(express@5.2.1)
+      hono: 4.12.32
+      jose: 6.2.4
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -3090,6 +3743,32 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
 
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.0)(redux@5.0.1))(react@19.2.0)':
     dependencies:
@@ -3389,9 +4068,25 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   adm-zip@0.5.18: {}
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -3484,6 +4179,20 @@ snapshots:
 
   baseline-browser-mapping@2.10.43: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
@@ -3507,6 +4216,18 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
@@ -3519,6 +4240,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
 
@@ -3536,6 +4259,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.3: {}
@@ -3546,9 +4271,26 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@11.1.0: {}
+
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3632,6 +4374,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3642,7 +4386,15 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.393: {}
 
@@ -3651,6 +4403,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.24.2:
     dependencies:
@@ -3667,9 +4421,44 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
   es-toolkit@1.49.0: {}
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -3677,7 +4466,15 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -3702,11 +4499,67 @@ snapshots:
       jest-mock: 30.4.1
       jest-util: 30.4.1
 
+  express-rate-limit@8.6.1(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.4: {}
 
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@4.1.0:
     dependencies:
@@ -3720,16 +4573,42 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  generic-pool@3.9.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@6.0.1: {}
 
@@ -3775,11 +4654,27 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.32: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -3798,6 +4693,10 @@ snapshots:
   human-signals@2.1.0: {}
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -3821,6 +4720,10 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ip-address@10.3.1: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-arrayish@0.2.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -3828,6 +4731,8 @@ snapshots:
   is-generator-fn@2.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -4193,6 +5098,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.4: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.15.0:
@@ -4230,6 +5137,10 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -4316,7 +5227,28 @@ snapshots:
     dependencies:
       escape-string-regexp: 4.0.0
 
+  math-intrinsics@1.1.0: {}
+
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(next@16.0.7(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
+      chalk: 5.6.2
+      commander: 11.1.0
+      redis: 4.7.1
+    optionalDependencies:
+      next: 16.0.7(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -4339,6 +5271,8 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   next@16.0.7(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -4376,7 +5310,15 @@ snapshots:
 
   nwsapi@2.2.24: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -4430,6 +5372,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -4441,6 +5385,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-to-regexp@8.4.2: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4448,6 +5394,8 @@ snapshots:
   picomatch@4.0.5: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -4494,9 +5442,28 @@ snapshots:
       '@types/node': 20.19.43
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
   pure-rand@7.0.1: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:
@@ -4545,6 +5512,15 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -4553,6 +5529,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   reselect@5.2.0: {}
 
   resolve-cwd@3.0.0:
@@ -4560,6 +5538,16 @@ snapshots:
       resolve-from: 5.0.0
 
   resolve-from@5.0.0: {}
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
 
   rrweb-cssom@0.8.0: {}
 
@@ -4575,9 +5563,36 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@8.1.0:
     dependencies:
       type-fest: 0.20.2
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -4617,6 +5632,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -4637,6 +5680,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  statuses@2.0.2: {}
 
   string-length@4.0.2:
     dependencies:
@@ -4714,6 +5759,8 @@ snapshots:
 
   tmpl@1.0.5: {}
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -4724,15 +5771,29 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.1:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-detect@4.0.8: {}
 
   type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -4776,6 +5837,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  vary@1.1.2: {}
 
   victory-vendor@37.3.6:
     dependencies:
@@ -4848,6 +5911,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yallist@4.0.0: {}
+
   yargs-parser@21.1.1: {}
 
   yargs@17.7.3:
@@ -4861,6 +5926,12 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}
 
   zustand@5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       mcp-handler:
         specifier: 1.1.0
         version: 1.1.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(next@16.0.7(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
@@ -1282,6 +1288,18 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2834,6 +2852,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -4067,6 +4088,19 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   accepts@2.0.0:
     dependencies:
@@ -5790,6 +5824,8 @@ snapshots:
       mime-types: 3.0.2
 
   typescript@5.9.3: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
+  esbuild: true
   onnxruntime-node: true
   protobufjs: false
   sharp: true

--- a/scripts/check-mcp.mjs
+++ b/scripts/check-mcp.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * End-to-end check of the MCP server against the *real* strategy model, over a
+ * real stdio JSON-RPC round-trip. The Jest suite (mcp/tools.test.ts) exercises
+ * the tool plumbing with a fake runner; this proves the shipped server, wired
+ * to onnxruntime-node and the checked-in .onnx, returns poker-sane strategy.
+ *
+ * Like scripts/check-onnx-runtime.mjs, it runs outside Jest (native addon +
+ * Jest's sandboxed contexts don't mix). Run: `pnpm check:mcp`.
+ */
+
+import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const transport = new StdioClientTransport({
+  command: "node_modules/.bin/tsx",
+  args: ["mcp/server.ts"],
+});
+const client = new Client({ name: "check-mcp", version: "0" });
+
+const json = (res) => JSON.parse(res.content[0].text);
+const sum = (xs) => xs.reduce((a, b) => a + b, 0);
+
+try {
+  await client.connect(transport);
+
+  // 1) both tools are advertised
+  const { tools } = await client.listTools();
+  assert.deepEqual(
+    tools.map((t) => t.name).sort(),
+    ["get_gto_strategy", "get_range_grid"],
+    "both tools should be listed",
+  );
+
+  // 2) get_gto_strategy: AKs preflop open is a valid, normalized mix that
+  //    (almost) never folds — a basic sanity floor on the real net.
+  const strat = json(
+    await client.callTool({
+      name: "get_gto_strategy",
+      arguments: { hero: "As Ks", position: "SB" },
+    }),
+  );
+  assert.equal(strat.node.street, "Preflop");
+  const total = sum(strat.strategy.map((a) => a.probability));
+  assert.ok(Math.abs(total - 1) < 1e-6, `probs sum to 1 (got ${total})`);
+  const fold = strat.strategy.find((a) => a.token === "f");
+  assert.ok(
+    !fold || fold.probability < 0.05,
+    `AKs should rarely fold preflop (fold=${fold?.probability})`,
+  );
+
+  // 3) get_range_grid: the SB opening range covers all 169 classes, AA opens
+  //    (~never folds) and 72o mostly folds — the shape a solver must produce.
+  const grid = json(
+    await client.callTool({ name: "get_range_grid", arguments: {} }),
+  );
+  assert.equal(Object.keys(grid.hands).length, 169, "all 169 classes present");
+  assert.ok(
+    Math.abs(sum(grid.aggregate) - 1) < 1e-6,
+    "aggregate mix sums to 1",
+  );
+  assert.ok(
+    grid.hands.AA.mix[0] < 0.05,
+    `AA should rarely fold (fold=${grid.hands.AA.mix[0]})`,
+  );
+  assert.ok(
+    grid.hands["72o"].mix[0] > 0.5,
+    `72o should mostly fold (fold=${grid.hands["72o"].mix[0]})`,
+  );
+
+  console.log("check:mcp OK — server + real model return poker-sane strategy");
+} catch (err) {
+  console.error("check:mcp FAILED:", err?.message ?? err);
+  process.exitCode = 1;
+} finally {
+  await client.close();
+}

--- a/src/app/(public)/agents/page.tsx
+++ b/src/app/(public)/agents/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from "next";
+import CodeBlock from "@/components/agents/CodeBlock";
+
+export const metadata: Metadata = {
+  title: "AI Agents",
+  description:
+    "Connect GTO Lab to Claude, Cursor, and other AI assistants over MCP and ask poker questions in plain English — answered straight from the solver.",
+};
+
+const HOSTED_URL = "https://gto-thingy.vercel.app/api/mcp";
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-12">
+      <h2 className="text-xl sm:text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">
+        {title}
+      </h2>
+      <div className="mt-4 space-y-4 text-sm sm:text-base leading-relaxed text-slate-600 dark:text-slate-400">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/40 p-4 sm:p-5">
+      {children}
+    </div>
+  );
+}
+
+export default function AgentsPage() {
+  return (
+    <main className="container mx-auto max-w-2xl px-4 sm:px-6 pt-14 sm:pt-20 pb-16 sm:pb-24">
+      <span className="inline-block rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+        New — connect your AI
+      </span>
+
+      <h1 className="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-white text-balance">
+        Use GTO Lab from your AI assistant
+      </h1>
+
+      <p className="mt-5 text-base sm:text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+        GTO Lab plugs into AI assistants like Claude and Cursor, so you can ask
+        poker questions in plain English and get answers straight from the
+        solver — the same Deep&nbsp;CFR strategy that powers this site. No
+        coding required: paste one link into your app and you&apos;re connected.
+      </p>
+
+      <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+        It works through{" "}
+        <a
+          href="https://modelcontextprotocol.io"
+          className="underline underline-offset-2 hover:text-slate-700 dark:hover:text-slate-200"
+        >
+          MCP
+        </a>{" "}
+        (Model Context Protocol), the standard way AI apps connect to outside
+        tools.
+      </p>
+
+      <Section title="What you can ask">
+        <p>
+          Once connected, your assistant can answer questions like these by
+          calling the solver directly:
+        </p>
+        <ul className="space-y-2">
+          {[
+            "“I have As Ks in the small blind — what's the GTO play?”",
+            "“On J♥ 7♣ 2♠ after I raise and get called, how often should I c-bet?”",
+            "“Show me the big blind's calling range facing a small-blind open.”",
+          ].map((q) => (
+            <li
+              key={q}
+              className="rounded-md border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/50 px-3 py-2 text-slate-700 dark:text-slate-300"
+            >
+              {q}
+            </li>
+          ))}
+        </ul>
+        <p className="text-sm">
+          Under the hood it exposes two tools —{" "}
+          <span className="font-mono text-slate-700 dark:text-slate-300">
+            get_gto_strategy
+          </span>{" "}
+          (the best action mix at one decision) and{" "}
+          <span className="font-mono text-slate-700 dark:text-slate-300">
+            get_range_grid
+          </span>{" "}
+          (the full 13×13 starting-hand chart). Your assistant picks the right
+          one automatically.
+        </p>
+      </Section>
+
+      <Section title="Quick connect">
+        <p>
+          The address of the GTO Lab server is a single link. Copy it —
+          you&apos;ll paste it into your AI app below.
+        </p>
+        <CodeBlock code={HOSTED_URL} label="GTO Lab MCP server URL" />
+
+        <div className="space-y-5 mt-2">
+          <Card>
+            <h3 className="font-semibold text-slate-900 dark:text-white">
+              Claude Desktop
+            </h3>
+            <ol className="mt-2 ml-4 list-decimal space-y-1 text-sm">
+              <li>
+                Open <strong>Settings → Connectors</strong> (or{" "}
+                <strong>Developer</strong>).
+              </li>
+              <li>
+                Choose <strong>Add custom connector</strong> and paste the URL
+                above.
+              </li>
+              <li>Save, then start a new chat and ask a poker question.</li>
+            </ol>
+          </Card>
+
+          <Card>
+            <h3 className="font-semibold text-slate-900 dark:text-white">
+              Cursor, Windsurf, and other config-file apps
+            </h3>
+            <p className="mt-2 text-sm">
+              Add GTO Lab to the app&apos;s MCP config (in Cursor:{" "}
+              <strong>Settings → MCP → Add new server</strong>):
+            </p>
+            <div className="mt-3">
+              <CodeBlock
+                code={`{
+  "mcpServers": {
+    "gto-lab": {
+      "url": "${HOSTED_URL}"
+    }
+  }
+}`}
+              />
+            </div>
+          </Card>
+
+          <Card>
+            <h3 className="font-semibold text-slate-900 dark:text-white">
+              Claude Code (terminal)
+            </h3>
+            <p className="mt-2 text-sm">Run one command:</p>
+            <div className="mt-3">
+              <CodeBlock
+                code={`claude mcp add --transport http gto-lab ${HOSTED_URL}`}
+              />
+            </div>
+          </Card>
+
+          <Card>
+            <h3 className="font-semibold text-slate-900 dark:text-white">
+              App only supports “command” servers?
+            </h3>
+            <p className="mt-2 text-sm">
+              Some older apps can&apos;t take a URL directly. Use this bridge
+              config instead — it needs{" "}
+              <a
+                href="https://nodejs.org"
+                className="underline underline-offset-2 hover:text-slate-700 dark:hover:text-slate-200"
+              >
+                Node.js
+              </a>{" "}
+              installed:
+            </p>
+            <div className="mt-3">
+              <CodeBlock
+                code={`{
+  "mcpServers": {
+    "gto-lab": {
+      "command": "npx",
+      "args": ["mcp-remote", "${HOSTED_URL}"]
+    }
+  }
+}`}
+              />
+            </div>
+          </Card>
+        </div>
+      </Section>
+
+      <Section title="Good to know">
+        <ul className="space-y-2 list-disc ml-4">
+          <li>
+            <strong>It&apos;s free.</strong> The hosted server is shared and
+            rate-limited (about 30 requests per minute) so everyone gets a turn.
+          </li>
+          <li>
+            <strong>Heads-up, 100&nbsp;big&nbsp;blinds.</strong> The solver
+            covers 1-v-1 No-Limit Hold&apos;em with ½-pot, pot, 2×-pot and
+            all-in bet sizes — the same model as the rest of this site.
+          </li>
+          <li>
+            <strong>Your prompts aren&apos;t stored.</strong> Each request is
+            answered and forgotten.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="Run your own (developers)">
+        <p>
+          Want higher limits or to run it locally? The server is open source —
+          host your own on Vercel, or run it over stdio from a clone. Full
+          instructions, including the two tools&apos; exact inputs:
+        </p>
+        <p className="text-sm">
+          <a
+            href="https://github.com/alfredzimmer/gto-lab/blob/main/mcp/README.md"
+            className="underline underline-offset-2 hover:text-slate-700 dark:hover:text-slate-200"
+          >
+            MCP server docs on GitHub →
+          </a>
+        </p>
+      </Section>
+    </main>
+  );
+}

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { createMcpHandler } from "mcp-handler";
+import { enforceRateLimit } from "@/lib/ratelimit";
 import { registerGtoTools } from "../../../../mcp/tools";
 import { runStrategyBatch } from "../../../../mcp/runner-wasm";
 
@@ -16,12 +17,23 @@ export const runtime = "nodejs";
 // Cold starts load the wasm runtime + model; give tool calls room.
 export const maxDuration = 60;
 
-const handler = createMcpHandler(
+const mcpHandler = createMcpHandler(
   (server) => {
     registerGtoTools(server, runStrategyBatch);
   },
   {},
   { basePath: "/api" },
 );
+
+// Per-IP rate limit in front of the MCP handler so the shared hosted instance
+// can't be abused. Inert unless Upstash credentials are set (see lib/ratelimit).
+async function handler(req: Request, ...rest: unknown[]): Promise<Response> {
+  const limited = await enforceRateLimit(req);
+  if (limited) return limited;
+  return (mcpHandler as (r: Request, ...a: unknown[]) => Promise<Response>)(
+    req,
+    ...rest,
+  );
+}
 
 export { handler as GET, handler as POST };

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -1,0 +1,27 @@
+/**
+ * Remote MCP endpoint — the same GTO Lab tools as the local stdio server
+ * (mcp/server.ts), served over Streamable HTTP so any MCP client can reach
+ * them at https://<deployment>/api/mcp. Inference runs in this Node serverless
+ * function via onnxruntime-web/wasm (no native addon), so it deploys on stock
+ * Vercel. The [transport] segment lets mcp-handler mount both /api/mcp
+ * (Streamable HTTP) and /api/sse from one file.
+ */
+
+import { createMcpHandler } from "mcp-handler";
+import { registerGtoTools } from "../../../../mcp/tools";
+import { runStrategyBatch } from "../../../../mcp/runner-wasm";
+
+// ONNX inference needs the Node runtime + filesystem — never the edge runtime.
+export const runtime = "nodejs";
+// Cold starts load the wasm runtime + model; give tool calls room.
+export const maxDuration = 60;
+
+const handler = createMcpHandler(
+  (server) => {
+    registerGtoTools(server, runStrategyBatch);
+  },
+  {},
+  { basePath: "/api" },
+);
+
+export { handler as GET, handler as POST };

--- a/src/components/agents/CodeBlock.tsx
+++ b/src/components/agents/CodeBlock.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * A copyable code/command block for the Agents setup page. Non-coders can
+ * one-click copy the exact URL or config without worrying about selecting text.
+ */
+export default function CodeBlock({
+  code,
+  label,
+}: {
+  code: string;
+  label?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard blocked (insecure context / permissions) — selecting still works.
+    }
+  };
+
+  return (
+    <div className="relative group">
+      {label && (
+        <div className="text-xs font-medium text-slate-500 dark:text-slate-400 mb-1.5">
+          {label}
+        </div>
+      )}
+      <pre className="overflow-x-auto rounded-md border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/60 p-3 pr-12 text-xs sm:text-sm font-mono text-slate-800 dark:text-slate-200">
+        <code>{code}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        className="absolute top-2 right-2 rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+        aria-label="Copy to clipboard"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ export default function Header() {
     { name: "Ranges", href: "/ranges" },
     { name: "Trainer", href: "/trainer" },
     { name: "Play", href: "/play" },
+    { name: "AI Agents", href: "/agents" },
   ];
 
   return (

--- a/src/lib/ratelimit.test.ts
+++ b/src/lib/ratelimit.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the MCP endpoint's per-IP rate limiter. Upstash is mocked so the
+ * three states can be driven directly — disabled (no creds), allowed, and
+ * over-budget — plus the two fail-open guarantees (no creds, and Redis errors).
+ * The module reads env + builds the limiter at import time, so each scenario
+ * re-imports it under a controlled environment.
+ */
+
+type LimitResult = {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  reset: number;
+};
+
+// Prefixed `mock*` so Jest allows referencing it inside the hoisted factory.
+let mockLimit: (key: string) => Promise<LimitResult>;
+let mockLastKey: string | undefined;
+
+jest.mock("@upstash/redis", () => ({
+  Redis: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("@upstash/ratelimit", () => ({
+  Ratelimit: Object.assign(
+    jest.fn().mockImplementation(() => ({
+      limit: (key: string) => {
+        mockLastKey = key;
+        return mockLimit(key);
+      },
+    })),
+    { slidingWindow: jest.fn(() => "sliding-window") },
+  ),
+}));
+
+const ORIGINAL_ENV = process.env;
+
+async function load(env: Record<string, string | undefined>) {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV, ...env };
+  return import("./ratelimit");
+}
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request("https://x/api/mcp", { method: "POST", headers });
+}
+
+beforeEach(() => {
+  mockLastKey = undefined;
+  mockLimit = async () => ({
+    success: true,
+    limit: 30,
+    remaining: 29,
+    reset: Date.now() + 60_000,
+  });
+});
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+const CREDS = {
+  UPSTASH_REDIS_REST_URL: "https://fake.upstash.io",
+  UPSTASH_REDIS_REST_TOKEN: "tok",
+};
+
+describe("fail-open when disabled", () => {
+  test("no credentials → limiter inert, every request passes", async () => {
+    const { enforceRateLimit, rateLimitEnabled } = await load({
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    expect(rateLimitEnabled).toBe(false);
+    expect(await enforceRateLimit(req())).toBeNull();
+  });
+});
+
+describe("enabled with credentials", () => {
+  test("under budget → allowed (null)", async () => {
+    const { enforceRateLimit, rateLimitEnabled } = await load(CREDS);
+    expect(rateLimitEnabled).toBe(true);
+    expect(await enforceRateLimit(req())).toBeNull();
+  });
+
+  test("over budget → 429 with Retry-After and ratelimit headers", async () => {
+    const reset = Date.now() + 15_000;
+    mockLimit = async () => ({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset,
+    });
+    const { enforceRateLimit } = await load(CREDS);
+
+    const res = await enforceRateLimit(req());
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(429);
+    expect(res?.headers.get("x-ratelimit-limit")).toBe("30");
+    expect(res?.headers.get("x-ratelimit-remaining")).toBe("0");
+    const retry = Number(res?.headers.get("retry-after"));
+    expect(retry).toBeGreaterThan(0);
+    expect(retry).toBeLessThanOrEqual(15);
+
+    const body = await res?.json();
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.error.message).toMatch(/rate limit exceeded/i);
+  });
+
+  test("Redis error → fail-open (allowed), does not throw", async () => {
+    mockLimit = async () => {
+      throw new Error("redis unreachable");
+    };
+    const { enforceRateLimit } = await load(CREDS);
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(await enforceRateLimit(req())).toBeNull();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("client IP keying", () => {
+  test("uses the first hop of x-forwarded-for", async () => {
+    const { enforceRateLimit } = await load(CREDS);
+    await enforceRateLimit(req({ "x-forwarded-for": "1.2.3.4, 10.0.0.1" }));
+    expect(mockLastKey).toBe("1.2.3.4");
+  });
+
+  test("falls back to x-real-ip, then anonymous", async () => {
+    const { enforceRateLimit } = await load(CREDS);
+    await enforceRateLimit(req({ "x-real-ip": "9.9.9.9" }));
+    expect(mockLastKey).toBe("9.9.9.9");
+    await enforceRateLimit(req());
+    expect(mockLastKey).toBe("anonymous");
+  });
+});

--- a/src/lib/ratelimit.test.ts
+++ b/src/lib/ratelimit.test.ts
@@ -119,6 +119,20 @@ describe("enabled with credentials", () => {
 });
 
 describe("client IP keying", () => {
+  test("prefers x-vercel-forwarded-for over a caller-supplied x-forwarded-for", async () => {
+    const { enforceRateLimit } = await load(CREDS);
+    // The whole point of the preference: x-forwarded-for is appended to, so a
+    // caller can put anything in its leftmost slot. Keying on that would let one
+    // client mint a fresh bucket per request. The Vercel-set header wins.
+    await enforceRateLimit(
+      req({
+        "x-forwarded-for": "203.0.113.99",
+        "x-vercel-forwarded-for": "1.2.3.4",
+      }),
+    );
+    expect(mockLastKey).toBe("1.2.3.4");
+  });
+
   test("uses the first hop of x-forwarded-for", async () => {
     const { enforceRateLimit } = await load(CREDS);
     await enforceRateLimit(req({ "x-forwarded-for": "1.2.3.4, 10.0.0.1" }));

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -1,0 +1,87 @@
+/**
+ * Per-IP rate limiting for the hosted MCP endpoint (src/app/api/[transport]),
+ * so the shared instance can't be hammered. Uses @upstash/ratelimit over
+ * Upstash Redis — connectionless HTTP, the standard for Vercel serverless.
+ *
+ * Fail-open: with no Upstash credentials in the environment (local dev, the
+ * stdio server, self-hosters who don't want limiting) this is inert and every
+ * request passes. It only engages once UPSTASH_REDIS_REST_URL and
+ * UPSTASH_REDIS_REST_TOKEN are set.
+ */
+
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+/** Requests allowed per IP per rolling window. Tune for interactive agent use. */
+const LIMIT = 30;
+const WINDOW = "60 s" as const;
+
+// One warm instance can serve many requests; an in-process cache lets obviously
+// over-limit IPs short-circuit without a Redis round-trip every time.
+const ephemeralCache = new Map<string, number>();
+
+const limiter: Ratelimit | null = (() => {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null; // fail-open — no credentials, no limiting
+  return new Ratelimit({
+    redis: new Redis({ url, token }),
+    limiter: Ratelimit.slidingWindow(LIMIT, WINDOW),
+    ephemeralCache,
+    prefix: "mcp",
+    analytics: true,
+  });
+})();
+
+/** True when limiting is actually active (credentials present). */
+export const rateLimitEnabled = limiter !== null;
+
+/** Best-effort client IP from the proxy headers Vercel sets. */
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0].trim();
+  return req.headers.get("x-real-ip") ?? "anonymous";
+}
+
+/**
+ * Enforce the per-IP limit for `req`. Returns a 429 `Response` to short-circuit
+ * the route when the caller is over budget, or `null` to let it proceed
+ * (including always, when limiting is disabled).
+ */
+export async function enforceRateLimit(req: Request): Promise<Response | null> {
+  if (!limiter) return null;
+
+  let result: Awaited<ReturnType<Ratelimit["limit"]>>;
+  try {
+    result = await limiter.limit(clientIp(req));
+  } catch (err) {
+    // A Redis outage must not take the endpoint down — fail open and log.
+    console.error("rate limit check failed, allowing request:", err);
+    return null;
+  }
+
+  const { success, limit, remaining, reset } = result;
+  if (success) return null;
+
+  const retryAfter = Math.max(0, Math.ceil((reset - Date.now()) / 1000));
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code: -32029, // implementation-defined; signals "slow down"
+        message: `Rate limit exceeded — ${limit} requests per ${WINDOW}. Retry in ${retryAfter}s.`,
+      },
+      id: null,
+    }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json",
+        "retry-after": String(retryAfter),
+        "x-ratelimit-limit": String(limit),
+        "x-ratelimit-remaining": String(remaining),
+        "x-ratelimit-reset": String(reset),
+      },
+    },
+  );
+}

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -36,8 +36,23 @@ const limiter: Ratelimit | null = (() => {
 /** True when limiting is actually active (credentials present). */
 export const rateLimitEnabled = limiter !== null;
 
-/** Best-effort client IP from the proxy headers Vercel sets. */
+/**
+ * Client IP to key the limit on, preferring the header the platform writes over
+ * the one the caller can write.
+ *
+ * `x-forwarded-for` is caller-writable: proxies *append* to it, so its leftmost
+ * entry is whatever the original client claimed about itself. Anywhere upstream
+ * appends rather than overwrites, keying on that entry lets one caller mint a
+ * fresh bucket per request and the limit stops binding at all.
+ *
+ * `x-vercel-forwarded-for` is set by Vercel's own proxy, which drops any
+ * client-supplied copy, so it can't be forged. Prefer it; fall back to the
+ * previous chain everywhere else (self-hosted, local dev), where the fallback is
+ * no worse than what it replaces.
+ */
 function clientIp(req: Request): string {
+  const trusted = req.headers.get("x-vercel-forwarded-for");
+  if (trusted) return trusted.split(",")[0].trim();
   const fwd = req.headers.get("x-forwarded-for");
   if (fwd) return fwd.split(",")[0].trim();
   return req.headers.get("x-real-ip") ?? "anonymous";


### PR DESCRIPTION
## What

Exposes the GTO Lab solver to AI agents over [MCP](https://modelcontextprotocol.io) — so an agent can ask *"what's GTO here?"* or *"show me the BB's response range vs an SB open"* and get answers straight from the Deep CFR strategy net.

Two tools, two transports, one set of tool definitions:

| Tool | Returns |
|---|---|
| `get_gto_strategy` | the Nash action mix at a hero decision |
| `get_range_grid` | the 13×13 range for the player to act on a public line |

Each tool takes a **friendly layer** (`hero: "As Ks"`, `position: "SB"`, `board`, a plain-English `line`) and a **raw layer** (the internal token `History`) for power use.

## How

- All poker logic **reuses the parity-tested engine** in `src/lib/gto/` — no rules re-implemented. The only new game-facing code is `mcp/notation.ts` (friendly ↔ `History` translation; numeric bet sizes snap to the nearest legal discrete size).
- Both transports call `registerGtoTools(server, runBatch)`; the sole difference is the injected inference runner:
  - **Local stdio** (`mcp/server.ts`, `pnpm mcp`) → `onnxruntime-node`.
  - **Remote HTTP** (`src/app/api/[transport]/route.ts`, `/api/mcp`) → `onnxruntime-web/wasm` via `mcp-handler`. Pure WASM, **no native addon**, so it deploys on stock Vercel.
- The two ONNX runtimes agree to **~3e-8**, so stdio and HTTP return byte-identical strategy.
- `next.config.ts` keeps `onnxruntime-web` unbundled and traces the model + wasm runtime into the serverless function.

## Hosted instance + how to connect

A hosted instance runs at **`https://gto-thingy.vercel.app/api/mcp`** — connect with zero setup:

```json
{ "mcpServers": { "gto-lab": { "url": "https://gto-thingy.vercel.app/api/mcp" } } }
```

Docs cover this plus self-hosting, local stdio (`pnpm mcp`), and a checked-in `.mcp.json` that auto-offers the stdio server to Claude Code. Top-level `README.md` has a new "Use it from an AI agent (MCP)" section; `mcp/README.md` is the full tool reference.

## Rate limiting

The hosted endpoint is protected by a per-IP limit (`src/lib/ratelimit.ts`) via `@upstash/ratelimit` over Upstash Redis — the standard for Vercel serverless. Default **30 req / 60s / IP**, sliding window, `429` + `Retry-After` when exceeded. **Fail-open**: inert unless `UPSTASH_REDIS_REST_URL/TOKEN` are set (so local/self-host are unaffected), and also fails open if Redis is unreachable so an outage can't down the endpoint. Env vars in `.env.example`.

## Verification

- ✅ stdio round-trip (`mcp/client-test.ts`), HTTP round-trip (`mcp/http-test.ts`)
- ✅ production `next build` + `next start` serving inference identically to dev (incl. through the rate-limit wrapper, fail-open with no creds)
- ✅ all three assets (model + both wasm files) traced into the route bundle
- ✅ `biome check` clean; existing `pnpm test` suite (77 tests) still green
- Output sanity: AKs opens ~94%, 72o folds ~98%, AA never folds, reasonable postflop c-bet mixes
- ⚠️ **Not yet validated on a live Vercel deploy**, and the active 429 path needs live Upstash creds to exercise (fail-open path is verified). Confirm both on first deploy.

## Not in scope (natural follow-ons)

- `get_equity_vs_range`, `evaluate_hand`, `generate_practice_spot` (library functions already exist)
- Auth on the public endpoint; packaging the stdio server as an `npx` bin